### PR TITLE
feat: Add command arg to choose SyncMode for Streamer

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -25,7 +25,7 @@ pub(crate) enum SubCommand {
 
 #[derive(Clap, Debug)]
 pub(crate) struct RunArgs {
-    /// streamer SyncMode. Possible values
+    /// streamer SyncMode. Possible values: from-interruption, last-synced and block. Default: from-interruption
     #[clap(long, default_value = "from-interruption")]
     pub sync_mode: SyncMode,
     /// block height for block sync mode

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use clap::Clap;
 #[macro_use]
 extern crate diesel;
@@ -8,7 +10,6 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 use crate::configs::{Opts, SubCommand};
-use std::convert::TryInto;
 
 mod configs;
 mod db_adapters;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use tracing_subscriber::EnvFilter;
 
 use crate::configs::{Opts, SubCommand};
+use std::convert::TryInto;
 
 mod configs;
 mod db_adapters;
@@ -96,11 +97,12 @@ fn main() {
         .unwrap_or_else(|| std::path::PathBuf::from(near_indexer::get_default_home()));
 
     match opts.subcmd {
-        SubCommand::Run => {
+        SubCommand::Run(args) => {
             let indexer_config = near_indexer::IndexerConfig {
                 home_dir,
-                sync_mode: near_indexer::SyncModeEnum::FromInterruption,
+                sync_mode: args.try_into().expect("Error in run arguments"),
             };
+            eprintln!("{:#?}", indexer_config);
             let indexer = near_indexer::Indexer::new(indexer_config);
             let stream = indexer.streamer();
             actix::spawn(listen_blocks(stream));


### PR DESCRIPTION
closes #15 

Command to run Indexer for Explorer updated

Before
```
indexer-binary --home-dir ~/.near/testnet run
```

After

```
indexer-binary --home-dir ~/.near/testnet run --sync-mode from-interruption
indexer-binary --home-dir ~/.near/testnet run --sync-mode last-synced
indexer-binary --home-dir ~/.near/testnet run --sync-mode block --height <block_height>
```

However the "before" command still works and `--sync-mode` default will be `from-interruption`