### PR TITLE
feat: Add accounts from genesis on start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1564,6 +1564,7 @@ dependencies = [
  "dotenv",
  "futures",
  "hex",
+ "itertools",
  "near-indexer",
  "num-traits",
  "openssl-probe",
@@ -1614,6 +1615,15 @@ dependencies = [
  "widestring",
  "winapi 0.3.9",
  "winreg",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,7 +1890,7 @@ dependencies = [
 [[package]]
 name = "near-actix-utils"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
 ]
@@ -1898,7 +1898,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "cached",
@@ -1926,7 +1926,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1936,13 +1936,14 @@ dependencies = [
  "num-rational",
  "serde",
  "serde_json",
+ "sha2",
  "smart-default",
 ]
 
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "borsh",
@@ -1964,7 +1965,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "ansi_term 0.11.0",
@@ -1998,7 +1999,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2024,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "cached",
@@ -2045,7 +2046,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.3.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "futures",
@@ -2062,7 +2063,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2088,7 +2089,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix-web",
  "futures",
@@ -2101,7 +2102,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "lazy_static",
  "log",
@@ -2111,7 +2112,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "borsh",
@@ -2140,7 +2141,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2151,7 +2152,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -2182,7 +2183,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2193,7 +2194,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2206,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "near-primitives",
  "near-runtime-fees",
@@ -2217,7 +2218,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-fees"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "num-rational",
  "serde",
@@ -2226,12 +2227,12 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 
 [[package]]
 name = "near-store"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2253,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "actix-web",
@@ -2267,7 +2268,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "near-rpc-error-macro",
@@ -2277,7 +2278,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "base64 0.11.0",
  "bs58",
@@ -2293,7 +2294,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "cached",
  "near-runtime-fees",
@@ -2308,7 +2309,7 @@ dependencies = [
 [[package]]
 name = "neard"
 version = "1.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "actix",
  "actix-web",
@@ -2374,7 +2375,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=e76b8dd1f7aca44e348844303d290c3b9c9a4387#e76b8dd1f7aca44e348844303d290c3b9c9a4387"
+source = "git+https://github.com/nearprotocol/nearcore?rev=bf9ae4ce8c680d3408db1935ebd0ca24c4960884#bf9ae4ce8c680d3408db1935ebd0ca24c4960884"
 dependencies = [
  "borsh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ diesel-derive-enum = { git = "https://github.com/khorolets/diesel-derive-enum.gi
 dotenv = "0.15.0"
 futures = "0.3.5"
 hex = "0.4"
+itertools = "0.9.0"
 num-traits = "0.2.11"
 openssl-probe = { version = "0.1.2" }
 r2d2 = "0.8.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ tokio-diesel = "0.3.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="e76b8dd1f7aca44e348844303d290c3b9c9a4387" }
+near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="bf9ae4ce8c680d3408db1935ebd0ca24c4960884" }

--- a/migrations/2020-10-14-092520_accounts_created_by_receipt_id_nullable/down.sql
+++ b/migrations/2020-10-14-092520_accounts_created_by_receipt_id_nullable/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts ALTER COLUMN created_by_receipt_id SET NOT NULL;

--- a/migrations/2020-10-14-092520_accounts_created_by_receipt_id_nullable/up.sql
+++ b/migrations/2020-10-14-092520_accounts_created_by_receipt_id_nullable/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE accounts ALTER COLUMN created_by_receipt_id DROP NOT NULL;

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -22,14 +22,17 @@ pub(crate) enum SubCommand {
     Init(InitConfigArgs),
 }
 
-#[derive(Clap, Debug)]
+#[derive(Clap, Debug, Clone)]
 pub(crate) struct RunArgs {
+    /// Store initial data from genesis like Accounts, AccessKeys
+    #[clap(long)]
+    pub store_genesis: bool,
     #[clap(subcommand)]
     pub sync_mode: SyncModeSubCommand,
 }
 
 #[allow(clippy::enum_variant_names)] // we want commands to be more explicit
-#[derive(Clap, Debug)]
+#[derive(Clap, Debug, Clone)]
 pub(crate) enum SyncModeSubCommand {
     /// continue from the block Indexer was interrupted
     SyncFromInterruption,
@@ -39,7 +42,7 @@ pub(crate) enum SyncModeSubCommand {
     SyncFromBlock(BlockArgs),
 }
 
-#[derive(Clap, Debug)]
+#[derive(Clap, Debug, Clone)]
 pub(crate) struct BlockArgs {
     /// block height for block sync mode
     #[clap(long)]

--- a/src/models/accounts.rs
+++ b/src/models/accounts.rs
@@ -4,18 +4,21 @@ use schema::accounts;
 #[derive(Insertable, Debug, Clone)]
 pub struct Account {
     pub account_id: String,
-    pub created_by_receipt_id: String,
+    pub created_by_receipt_id: Option<String>,
     pub deleted_by_receipt_id: Option<String>,
 }
 
 impl Account {
     pub fn new(
         account_id: String,
-        created_by_receipt_id: &near_indexer::near_primitives::hash::CryptoHash,
+        created_by_receipt_id: Option<&near_indexer::near_primitives::hash::CryptoHash>,
     ) -> Self {
         Self {
             account_id,
-            created_by_receipt_id: created_by_receipt_id.to_string(),
+            created_by_receipt_id: match created_by_receipt_id {
+                Some(receipt_id) => Some(receipt_id.to_string()),
+                None => None,
+            },
             deleted_by_receipt_id: None,
         }
     }

--- a/src/models/accounts.rs
+++ b/src/models/accounts.rs
@@ -3,22 +3,27 @@ use schema::accounts;
 
 #[derive(Insertable, Debug, Clone)]
 pub struct Account {
-    pub account_id: String,
-    pub created_by_receipt_id: Option<String>,
-    pub deleted_by_receipt_id: Option<String>,
+    account_id: String,
+    created_by_receipt_id: Option<String>,
+    deleted_by_receipt_id: Option<String>,
 }
 
 impl Account {
-    pub fn new(
+    pub fn new_from_receipt(
         account_id: String,
-        created_by_receipt_id: Option<&near_indexer::near_primitives::hash::CryptoHash>,
+        created_by_receipt_id: &near_indexer::near_primitives::hash::CryptoHash,
     ) -> Self {
         Self {
             account_id,
-            created_by_receipt_id: match created_by_receipt_id {
-                Some(receipt_id) => Some(receipt_id.to_string()),
-                None => None,
-            },
+            created_by_receipt_id: Some(created_by_receipt_id.to_string()),
+            deleted_by_receipt_id: None,
+        }
+    }
+
+    pub fn new_from_genesis(account_id: String) -> Self {
+        Self {
+            account_id,
+            created_by_receipt_id: None,
             deleted_by_receipt_id: None,
         }
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -4,7 +4,7 @@ table! {
     accounts (id) {
         id -> Int8,
         account_id -> Text,
-        created_by_receipt_id -> Text,
+        created_by_receipt_id -> Nullable<Text>,
         deleted_by_receipt_id -> Nullable<Text>,
     }
 }


### PR DESCRIPTION
Closes #13 

Introduce additional parameter to `run` command `--store-genesis` (couldn't find better name) to include handling of genesis file on start of indexer.

Currently if activated will run the function that will walk over `genesis.records` to add records in db with accounts.

~**Note** If account is already present in db this handler will update `created_by_receipt_id` and `deleted_by_receipt_id` by setting them to `NULL` (assuming account is created in genesis and haven't been deleted), one should carefully use it on Indexer restart.~

@frol let me know what do you think about the behaviour described above.