### PR TITLE
fix: Fix/missing parent for receipt

### DIFF
--- a/migrations/2020-11-06-103108_data_id_add_index/down.sql
+++ b/migrations/2020-11-06-103108_data_id_add_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX action_output_data_id_idx;

--- a/migrations/2020-11-06-103108_data_id_add_index/up.sql
+++ b/migrations/2020-11-06-103108_data_id_add_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX action_output_data_id_idx ON receipt_action_output_data (data_id);

--- a/migrations/2020-11-06-104009_chunkd_index/down.sql
+++ b/migrations/2020-11-06-104009_chunkd_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX chunks_block_hash_idx;

--- a/migrations/2020-11-06-104009_chunkd_index/up.sql
+++ b/migrations/2020-11-06-104009_chunkd_index/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX chunks_block_hash_idx ON chunks (block_hash);

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -91,7 +91,6 @@ async fn find_tx_hashes_for_receipts(
     let mut retries_left: u8 = 10; // retry at least times even in no-strict mode to avoid data loss
     loop {
         let data_ids: Vec<String> = receipts
-            .clone()
             .iter()
             .filter_map(|r| match r.receipt {
                 near_indexer::near_primitives::views::ReceiptEnumView::Data { data_id, .. } => {


### PR DESCRIPTION
It appears to happen only in case of data-receipts, because we can't find previous receipt by `receipt_id`. Instead we need to look for receipt via `data_id` through `receipts_action_output_data`. I've changed the way we're looking for parent transaction for receipts to differentiate action-receipts and data-receipts.

fixes #39 
also closes #36 