### PR TITLE
refator: Rename account ID columns to include `_account_id` suffix

### DIFF
--- a/migrations/2020-11-06-113536_account_id_suffix/down.sql
+++ b/migrations/2020-11-06-113536_account_id_suffix/down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE receipts
+    RENAME COLUMN predecessor_account_id TO predecessor_id;
+
+ALTER TABLE receipts
+    RENAME COLUMN receiver_account_id TO receiver_id;
+
+ALTER TABLE receipt_action_output_data
+    RENAME COLUMN receiver_account_id TO receiver_id;
+
+ALTER TABLE execution_outcomes
+    RENAME COLUMN executor_account_id TO executor_id;

--- a/migrations/2020-11-06-113536_account_id_suffix/up.sql
+++ b/migrations/2020-11-06-113536_account_id_suffix/up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE receipts
+    RENAME COLUMN predecessor_id TO predecessor_account_id;
+ALTER TABLE receipts
+    RENAME COLUMN receiver_id TO receiver_account_id;
+
+ALTER TABLE receipt_action_output_data
+    RENAME COLUMN receiver_id TO receiver_account_id;
+
+ALTER TABLE execution_outcomes
+    RENAME COLUMN executor_id TO executor_account_id;

--- a/src/models/execution_outcomes.rs
+++ b/src/models/execution_outcomes.rs
@@ -14,7 +14,7 @@ pub struct ExecutionOutcome {
     pub block_hash: String,
     pub gas_burnt: BigDecimal,
     pub tokens_burnt: BigDecimal,
-    pub executor_id: String,
+    pub executor_account_id: String,
     pub status: ExecutionOutcomeStatus,
 }
 
@@ -30,7 +30,7 @@ impl From<&near_indexer::near_primitives::views::ExecutionOutcomeWithIdView> for
                 execution_outcome.outcome.tokens_burnt.to_string().as_str(),
             )
             .expect("`tokens_burnt` expected to be u128"),
-            executor_id: execution_outcome.outcome.executor_id.to_string(),
+            executor_account_id: execution_outcome.outcome.executor_id.to_string(),
             status: execution_outcome.outcome.status.clone().into(),
         }
     }

--- a/src/models/receipts.rs
+++ b/src/models/receipts.rs
@@ -19,8 +19,8 @@ pub struct Receipt {
     pub chunk_hash: String,
     pub index_in_chunk: i32,
     pub block_timestamp: BigDecimal,
-    pub predecessor_id: String,
-    pub receiver_id: String,
+    pub predecessor_account_id: String,
+    pub receiver_account_id: String,
     pub receipt_kind: ReceiptKind,
     pub transaction_hash: String,
 }
@@ -38,8 +38,8 @@ impl Receipt {
             receipt_id: receipt.receipt_id.to_string(),
             block_hash: block_hash.to_string(),
             chunk_hash: chunk_hash.to_string(),
-            predecessor_id: receipt.predecessor_id.to_string(),
-            receiver_id: receipt.receiver_id.to_string(),
+            predecessor_account_id: receipt.predecessor_id.to_string(),
+            receiver_account_id: receipt.receiver_id.to_string(),
             receipt_kind: (&receipt.receipt).into(),
             transaction_hash: transaction_hash.to_string(),
             index_in_chunk,
@@ -157,7 +157,7 @@ impl ReceiptActionInputData {
 pub struct ReceiptActionOutputData {
     pub receipt_id: String,
     pub data_id: String,
-    pub receiver_id: String,
+    pub receiver_account_id: String,
 }
 
 impl ReceiptActionOutputData {
@@ -165,7 +165,7 @@ impl ReceiptActionOutputData {
         Self {
             receipt_id,
             data_id: data_receiver.data_id.to_string(),
-            receiver_id: data_receiver.receiver_id.to_string(),
+            receiver_account_id: data_receiver.receiver_id.to_string(),
         }
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -69,7 +69,7 @@ table! {
         block_hash -> Text,
         gas_burnt -> Numeric,
         tokens_burnt -> Numeric,
-        executor_id -> Text,
+        executor_account_id -> Text,
         status -> Execution_outcome_status,
     }
 }
@@ -101,7 +101,7 @@ table! {
     receipt_action_output_data (data_id, receipt_id) {
         data_id -> Text,
         receipt_id -> Text,
-        receiver_id -> Text,
+        receiver_account_id -> Text,
     }
 }
 
@@ -136,8 +136,8 @@ table! {
         chunk_hash -> Text,
         index_in_chunk -> Int4,
         block_timestamp -> Numeric,
-        predecessor_id -> Text,
-        receiver_id -> Text,
+        predecessor_account_id -> Text,
+        receiver_account_id -> Text,
         receipt_kind -> Receipt_type,
         transaction_hash -> Text,
     }


### PR DESCRIPTION
Closes #37 