### PR TITLE
refactor: Upgrade dependencies and migrate from tokio-diesel to actix-diesel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
+## 0.2.3
+
+* Upgrade `nearcore` dependency
+* Upgrade some external dependencies (`actix`, `tokio`)
+
 ## 0.2.2
 
-* Fill `deleted_by_receipt_id` if `access_key` on owner account deletion 
+* Fill `deleted_by_receipt_id` if `access_key` on owner account deletion
 
 ## 0.2.1
 
 * Add `access_key` on transfer to implicit account action
-* Upgrade `nearcore` dependency 
+* Upgrade `nearcore` dependency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+* Migrate from `tokio-diesel` to `actix-diesel` (patched by @frol)
+
 ## 0.2.3
 
 * Upgrade `nearcore` dependency

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ dependencies = [
  "actix-rt",
  "actix_derive",
  "bitflags",
- "bytes 1.0.1",
+ "bytes",
  "crossbeam-channel",
  "derive_more",
  "futures-core",
@@ -19,9 +19,9 @@ dependencies = [
  "log",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "smallvec",
- "tokio 1.1.1",
+ "tokio",
  "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
@@ -34,12 +34,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90673465c6187bd0829116b02be465dc0195a74d7719f76ffff0effef934a92e"
 dependencies = [
  "bitflags",
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
- "tokio 1.1.1",
+ "pin-project-lite",
+ "tokio",
  "tokio-util",
 ]
 
@@ -71,7 +71,7 @@ dependencies = [
  "base64 0.13.0",
  "bitflags",
  "brotli2",
- "bytes 1.0.1",
+ "bytes",
  "bytestring",
  "cookie",
  "copyless",
@@ -144,7 +144,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac24f3f660d4c394cc6d24272e526083c257d6045d3be76a9d0a76be5cb56515"
 dependencies = [
  "actix-macros 0.2.0",
- "tokio 1.1.1",
+ "tokio",
 ]
 
 [[package]]
@@ -162,7 +162,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "slab",
- "tokio 1.1.1",
+ "tokio",
 ]
 
 [[package]]
@@ -172,7 +172,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6659eb09fcd1e57104269682c78d31965f3a087437e140c2ecbb3cd47042d671"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -245,7 +245,7 @@ dependencies = [
  "actix-web-codegen",
  "ahash 0.6.3",
  "awc",
- "bytes 1.0.1",
+ "bytes",
  "derive_more",
  "encoding_rs",
  "futures-core",
@@ -432,7 +432,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "base64 0.13.0",
- "bytes 1.0.1",
+ "bytes",
  "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
@@ -685,12 +685,6 @@ checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-
-[[package]]
-name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
@@ -701,7 +695,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
 ]
 
 [[package]]
@@ -1474,7 +1468,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1577,7 +1571,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1585,7 +1579,7 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio 1.1.1",
+ "tokio",
  "tokio-util",
  "tracing",
  "tracing-futures",
@@ -1650,7 +1644,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "fnv",
  "itoa",
 ]
@@ -1736,7 +1730,7 @@ dependencies = [
  "r2d2",
  "serde",
  "serde_json",
- "tokio 1.1.1",
+ "tokio",
  "tokio-diesel",
  "tokio-stream",
  "tracing",
@@ -2016,7 +2010,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "cached",
@@ -2044,7 +2038,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2062,7 +2056,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "chrono",
  "failure",
@@ -2074,7 +2068,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "borsh",
@@ -2096,7 +2090,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "ansi_term 0.12.1",
@@ -2133,7 +2127,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "chrono",
@@ -2149,7 +2143,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2173,7 +2167,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "cached",
@@ -2193,8 +2187,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.7.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+version = "0.8.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "futures",
@@ -2204,14 +2198,14 @@ dependencies = [
  "neard",
  "node-runtime",
  "rocksdb",
- "tokio 1.1.1",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2233,14 +2227,14 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "tokio 1.1.1",
+ "tokio",
  "validator",
 ]
 
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix-web",
  "futures",
@@ -2254,7 +2248,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "lazy_static",
@@ -2270,7 +2264,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "lazy_static",
  "log",
@@ -2280,12 +2274,12 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "borsh",
  "byteorder",
- "bytes 1.0.1",
+ "bytes",
  "cached",
  "chrono",
  "futures",
@@ -2303,7 +2297,7 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "tokio 1.1.1",
+ "tokio",
  "tokio-stream",
  "tokio-util",
  "tracing",
@@ -2312,7 +2306,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2327,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "quote",
  "syn",
@@ -2336,7 +2330,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2347,7 +2341,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2377,7 +2371,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2388,7 +2382,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2401,7 +2395,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "lazy_static",
  "near-primitives",
@@ -2413,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-fees"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "num-rational",
  "serde",
@@ -2422,7 +2416,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2446,7 +2440,7 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2467,7 +2461,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "actix-web",
@@ -2483,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "ethereum-types",
@@ -2495,7 +2489,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2513,7 +2507,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "cached",
@@ -2530,8 +2524,8 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.18.0-rc.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+version = "1.2.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "actix",
  "actix-web",
@@ -2588,7 +2582,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2905,12 +2899,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
@@ -3343,7 +3331,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "rustc-hex",
 ]
 
@@ -3899,30 +3887,19 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
-dependencies = [
- "bytes 0.5.6",
- "pin-project-lite 0.1.11",
- "slab",
-]
-
-[[package]]
-name = "tokio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
 dependencies = [
  "autocfg 1.0.1",
- "bytes 1.0.1",
+ "bytes",
  "libc",
  "memchr",
  "mio",
  "num_cpus",
  "once_cell",
  "parking_lot 0.11.1",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
@@ -3931,14 +3908,13 @@ dependencies = [
 [[package]]
 name = "tokio-diesel"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713f06058e12ed5adb542401b9d20f2b18b3fccf6184c5d77b57a31b3d21cc69"
+source = "git+https://github.com/mehcode/tokio-diesel?rev=f4af42558246ab323600622ba8d08803d3c18842#f4af42558246ab323600622ba8d08803d3c18842"
 dependencies = [
  "async-trait",
  "diesel",
  "futures",
  "r2d2",
- "tokio 0.2.25",
+ "tokio",
 ]
 
 [[package]]
@@ -3961,7 +3937,7 @@ dependencies = [
  "futures",
  "openssl",
  "pin-project 1.0.5",
- "tokio 1.1.1",
+ "tokio",
 ]
 
 [[package]]
@@ -3971,8 +3947,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
 dependencies = [
  "futures-core",
- "pin-project-lite 0.2.4",
- "tokio 1.1.1",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -3981,14 +3957,14 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes 1.0.1",
+ "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "slab",
- "tokio 1.1.1",
+ "tokio",
 ]
 
 [[package]]
@@ -4007,7 +3983,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "pin-project-lite 0.2.4",
+ "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -4105,7 +4081,7 @@ dependencies = [
  "rand 0.8.3",
  "smallvec",
  "thiserror",
- "tokio 1.1.1",
+ "tokio",
  "url",
 ]
 
@@ -4125,7 +4101,7 @@ dependencies = [
  "resolv-conf",
  "smallvec",
  "thiserror",
- "tokio 1.1.1",
+ "tokio",
  "trust-dns-proto",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,116 +2,82 @@
 # It is not intended for manual editing.
 [[package]]
 name = "actix"
-version = "0.9.0"
+version = "0.11.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4af87564ff659dee8f9981540cac9418c45e910c8072fdedd643a262a38fcaf"
+checksum = "37700c469661b14d50ad53dfd6fff215fe7496e8cf87484b9c8a809d5e922543"
 dependencies = [
- "actix-http",
+ "actix-macros 0.1.3",
  "actix-rt",
  "actix_derive",
  "bitflags",
- "bytes",
- "crossbeam-channel 0.4.4",
+ "bytes 1.0.1",
+ "crossbeam-channel",
  "derive_more",
- "futures",
- "lazy_static",
+ "futures-core",
+ "futures-sink",
+ "futures-task",
  "log",
- "parking_lot 0.10.2",
- "pin-project 0.4.27",
+ "once_cell",
+ "parking_lot 0.11.1",
+ "pin-project-lite 0.2.4",
  "smallvec",
- "tokio",
- "tokio-util 0.2.0",
+ "tokio 1.1.1",
+ "tokio-util",
  "trust-dns-proto",
  "trust-dns-resolver",
 ]
 
 [[package]]
 name = "actix-codec"
-version = "0.2.0"
+version = "0.4.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e55f0a5c2ca15795035d90c46bd0e73a5123b72f68f12596d6ba5282051380"
+checksum = "90673465c6187bd0829116b02be465dc0195a74d7719f76ffff0effef934a92e"
 dependencies = [
  "bitflags",
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
- "tokio",
- "tokio-util 0.2.0",
-]
-
-[[package]]
-name = "actix-codec"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78d1833b3838dbe990df0f1f87baf640cf6146e898166afe401839d1b001e570"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project 0.4.27",
- "tokio",
- "tokio-util 0.3.1",
-]
-
-[[package]]
-name = "actix-connect"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c95cc9569221e9802bf4c377f6c18b90ef10227d787611decf79fd47d2a8e76c"
-dependencies = [
- "actix-codec 0.2.0",
- "actix-rt",
- "actix-service",
- "actix-utils 1.0.6",
- "derive_more",
- "either",
- "futures",
- "http",
- "log",
- "openssl",
- "tokio-openssl",
- "trust-dns-proto",
- "trust-dns-resolver",
+ "pin-project-lite 0.2.4",
+ "tokio 1.1.1",
+ "tokio-util",
 ]
 
 [[package]]
 name = "actix-cors"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6206917d5c0fdd79d81cec9ef02d3e802df4abf276d96241e1f595d971e002"
+version = "0.5.4"
+source = "git+https://github.com/near/actix-extras.git?branch=actix-web-4-beta#d7ac6473c7101088bcc448a74df6a0b2c19c6e1f"
 dependencies = [
- "actix-service",
  "actix-web",
  "derive_more",
- "futures",
+ "futures-util",
+ "log",
+ "once_cell",
+ "tinyvec",
 ]
 
 [[package]]
 name = "actix-http"
-version = "1.0.1"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c16664cc4fdea8030837ad5a845eb231fb93fc3c5c171edfefb52fad92ce9019"
+checksum = "80068c81f352ca6346c851461c41dc946160850f1b2f806af7bfa0820b7875c8"
 dependencies = [
- "actix-codec 0.2.0",
- "actix-connect",
+ "actix-codec",
  "actix-rt",
  "actix-service",
  "actix-threadpool",
  "actix-tls",
- "actix-utils 1.0.6",
- "base64 0.11.0",
+ "actix-utils",
+ "base64 0.13.0",
  "bitflags",
  "brotli2",
- "bytes",
- "chrono",
+ "bytes 1.0.1",
+ "bytestring",
+ "cookie",
  "copyless",
  "derive_more",
  "either",
  "encoding_rs",
- "failure",
  "flate2",
  "futures-channel",
  "futures-core",
@@ -121,20 +87,21 @@ dependencies = [
  "http",
  "httparse",
  "indexmap",
+ "itoa",
  "language-tags",
  "lazy_static",
  "log",
  "mime",
  "percent-encoding",
- "pin-project 0.4.27",
- "rand 0.7.3",
+ "pin-project 1.0.5",
+ "rand 0.8.3",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sha1",
+ "sha-1",
  "slab",
- "time",
+ "time 0.2.25",
 ]
 
 [[package]]
@@ -148,10 +115,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-router"
-version = "0.2.5"
+name = "actix-macros"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd1f7dbda1645bf7da33554db60891755f6c01c1b2169e2f4c492098d30c235"
+checksum = "dbcb2b608f0accc2f5bcf3dd872194ce13d94ee45b571487035864cf966b04ef"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "actix-router"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8be584b3b6c705a18eabc11c4059cf83b255bdd8511673d1d569f4ce40c69de"
 dependencies = [
  "bytestring",
  "http",
@@ -162,61 +139,40 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "1.1.1"
+version = "2.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143fcc2912e0d1de2bcf4e2f720d2a60c28652ab4179685a1ee159e0fb3db227"
+checksum = "ac24f3f660d4c394cc6d24272e526083c257d6045d3be76a9d0a76be5cb56515"
 dependencies = [
- "actix-macros",
- "actix-threadpool",
- "copyless",
- "futures-channel",
- "futures-util",
- "smallvec",
- "tokio",
+ "actix-macros 0.2.0",
+ "tokio 1.1.1",
 ]
 
 [[package]]
 name = "actix-server"
-version = "1.0.4"
+version = "2.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45407e6e672ca24784baa667c5d32ef109ccdd8d5e0b5ebb9ef8a67f4dfb708e"
+checksum = "4c41709672a16da36607e9392029d15f07d3ad4c34bbc399671d66b7ac53e65c"
 dependencies = [
- "actix-codec 0.3.0",
+ "actix-codec",
  "actix-rt",
  "actix-service",
- "actix-utils 2.0.0",
- "futures-channel",
- "futures-util",
+ "actix-utils",
+ "futures-core",
  "log",
  "mio",
- "mio-uds",
  "num_cpus",
  "slab",
- "socket2",
+ "tokio 1.1.1",
 ]
 
 [[package]]
 name = "actix-service"
-version = "1.0.6"
+version = "2.0.0-beta.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0052435d581b5be835d11f4eb3bce417c8af18d87ddf8ace99f8e67e595882bb"
+checksum = "6659eb09fcd1e57104269682c78d31965f3a087437e140c2ecbb3cd47042d671"
 dependencies = [
- "futures-util",
- "pin-project 0.4.27",
-]
-
-[[package]]
-name = "actix-testing"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47239ca38799ab74ee6a8a94d1ce857014b2ac36f242f70f3f75a66f691e791c"
-dependencies = [
- "actix-macros",
- "actix-rt",
- "actix-server",
- "actix-service",
- "log",
- "socket2",
+ "futures-core",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
@@ -236,102 +192,83 @@ dependencies = [
 
 [[package]]
 name = "actix-tls"
-version = "1.0.0"
+version = "3.0.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4e5b4faaf105e9a6d389c606c298dcdb033061b00d532af9df56ff3a54995a8"
+checksum = "c4f466bdd136f0ddf1614d6f725e41634faaa1e4ad04e180f06a598b5dfeebcd"
 dependencies = [
- "actix-codec 0.2.0",
+ "actix-codec",
  "actix-rt",
  "actix-service",
- "actix-utils 1.0.6",
+ "actix-utils",
  "derive_more",
  "either",
- "futures",
+ "futures-util",
+ "http",
  "log",
  "openssl",
  "tokio-openssl",
+ "trust-dns-proto",
+ "trust-dns-resolver",
 ]
 
 [[package]]
 name = "actix-utils"
-version = "1.0.6"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf8f5631bf01adec2267808f00e228b761c60c0584cc9fa0b5364f41d147f4e"
+checksum = "886712f09d0bd691030556ae770685d2dce8febc5d7cf0936912a5ba85602c95"
 dependencies = [
- "actix-codec 0.2.0",
+ "actix-codec",
  "actix-rt",
  "actix-service",
- "bitflags",
- "bytes",
- "either",
- "futures",
- "log",
- "pin-project 0.4.27",
- "slab",
-]
-
-[[package]]
-name = "actix-utils"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9022dec56632d1d7979e59af14f0597a28a830a9c1c7fec8b2327eb9f16b5a"
-dependencies = [
- "actix-codec 0.3.0",
- "actix-rt",
- "actix-service",
- "bitflags",
- "bytes",
- "either",
- "futures-channel",
+ "futures-core",
  "futures-sink",
- "futures-util",
  "log",
- "pin-project 0.4.27",
- "slab",
+ "pin-project-lite 0.2.4",
 ]
 
 [[package]]
 name = "actix-web"
-version = "2.0.0"
+version = "4.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3158e822461040822f0dbf1735b9c2ce1f95f93b651d7a7aded00b1efbb1f635"
+checksum = "262a62a6bc81bc809dc27a8369542d332577d6f9119ae25b038b8587e7d4a7c6"
 dependencies = [
- "actix-codec 0.2.0",
+ "actix-codec",
  "actix-http",
- "actix-macros",
+ "actix-macros 0.1.3",
  "actix-router",
  "actix-rt",
  "actix-server",
  "actix-service",
- "actix-testing",
  "actix-threadpool",
  "actix-tls",
- "actix-utils 1.0.6",
+ "actix-utils",
  "actix-web-codegen",
+ "ahash 0.6.3",
  "awc",
- "bytes",
+ "bytes 1.0.1",
  "derive_more",
  "encoding_rs",
- "futures",
- "fxhash",
+ "futures-core",
+ "futures-util",
  "log",
  "mime",
- "net2",
  "openssl",
- "pin-project 0.4.27",
+ "pin-project 1.0.5",
  "regex",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "time",
+ "smallvec",
+ "socket2",
+ "time 0.2.25",
  "url",
 ]
 
 [[package]]
 name = "actix-web-codegen"
-version = "0.2.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a71bf475cbe07281d0b3696abb48212db118e7e23219f13596ce865235ff5766"
+checksum = "ad26f77093333e0e7c6ffe54ebe3582d908a104e448723eec6d43d08b07143fb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -351,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c0929d69e78dd9bf5408269919fcbcaeb2e35e5d43e5815517cdc6a8e11a423"
+checksum = "a55f82cfe485775d02112886f4169bde0c5894d75e79ead7eafe7e40a25e45f7"
 dependencies = [
  "gimli",
 ]
@@ -363,6 +300,23 @@ name = "adler"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+
+[[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
+name = "ahash"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "796540673305a66d127804eef19ad696f1f204b8c1025aaca4958c17eab32877"
+dependencies = [
+ "getrandom 0.2.2",
+ "once_cell",
+ "version_check",
+]
 
 [[package]]
 name = "aho-corasick"
@@ -379,7 +333,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -388,7 +342,28 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "arr_macro"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a105bfda48707cf19220129e78fca01e9639433ffaef4163546ed8fb04120a5"
+dependencies = [
+ "arr_macro_impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "arr_macro_impl"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0609c78bd572f4edc74310dfb63a01f5609d53fa8b4dd7c4d98aef3b3e8d72d1"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -402,6 +377,15 @@ name = "arrayvec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
+
+[[package]]
+name = "async-mutex"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479db852db25d9dbf6204e6cb6253698f175c15726470f78af0d918e99d6156e"
+dependencies = [
+ "event-listener",
+]
 
 [[package]]
 name = "async-trait"
@@ -422,7 +406,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -439,23 +423,24 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "awc"
-version = "1.0.1"
+version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7601d4d1d7ef2335d6597a41b5fe069f6ab799b85f53565ab390e7b7065aac5"
+checksum = "180bcec5977648b3c6ca41589399d160cc57a50eeeb407a666d0153740a1c621"
 dependencies = [
- "actix-codec 0.2.0",
+ "actix-codec",
  "actix-http",
  "actix-rt",
  "actix-service",
- "base64 0.11.0",
- "bytes",
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "cfg-if 1.0.0",
  "derive_more",
  "futures-core",
  "log",
  "mime",
  "openssl",
  "percent-encoding",
- "rand 0.7.3",
+ "rand 0.8.3",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -463,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.55"
+version = "0.3.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef5140344c85b01f9bbb4d4b7288a8aa4b3287ccef913a14bcc78a1063623598"
+checksum = "9d117600f438b1707d4e4ae15d3595657288f8235a0eb593e80ecc98ab34e1bc"
 dependencies = [
  "addr2line",
  "cfg-if 1.0.0",
@@ -474,6 +459,12 @@ dependencies = [
  "object",
  "rustc-demangle",
 ]
+
+[[package]]
+name = "base-x"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
@@ -493,7 +484,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460825c9e21708024d67c07057cd5560e5acdccac85de0de624a81d3de51bacb"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
 ]
@@ -540,12 +531,14 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "bitvec"
-version = "0.17.4"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41262f11d771fd4a61aa3ce019fca363b4b6c282fca9da2a31186d3965a47a5c"
+checksum = "f5011ffc90248764d7005b0e10c7294f5aa1bd87d9dd7248f4ad475b347c294d"
 dependencies = [
- "either",
+ "funty",
  "radium",
+ "tap",
+ "wyz",
 ]
 
 [[package]]
@@ -603,29 +596,32 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30f3fd65922359a7c6e791bc9b2bba1b977ea0c0b96a528ac48007f535fb4184"
+checksum = "a5a26c53ddf60281f18e7a29b20db7ba3db82a9d81b9650bfaa02d646f50d364"
 dependencies = [
  "borsh-derive",
+ "hashbrown",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2d74755d937d261d5e9bdef87e0addfbc1ace0214f7776f21532d6e97325356"
+checksum = "b637a47728b78a78cd7f4b85bf06d71ef4221840e059a38f048be2422bf673b2"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
+ "proc-macro-crate",
+ "proc-macro2",
  "syn",
 ]
 
 [[package]]
 name = "borsh-derive-internal"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c9f966cb7a42c8ed83546ef481bc1d1dec888fe5f84a4737d5c2094a483e41e"
+checksum = "d813fa25eb0bed78c36492cff4415f38c760d6de833d255ba9095bd8ebb7d725"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -634,9 +630,9 @@ dependencies = [
 
 [[package]]
 name = "borsh-schema-derive-internal"
-version = "0.7.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df2543b56ebc2b4493e70d024ebde2cbb48d97bf7b1a16318eff30bd02669b8"
+checksum = "dcf78ee4a98c8cb9eba1bac3d3e2a1ea3d7673c719ce691e67b5cbafc472d3b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -665,21 +661,27 @@ dependencies = [
 
 [[package]]
 name = "bs58"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "476e9cd489f9e121e02ffa6014a8ef220ecb15c05ed23fc34cca13925dc283fb"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+
+[[package]]
+name = "bumpalo"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
 
 [[package]]
 name = "byte-slice-cast"
-version = "0.3.5"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0a5e3906bcbf133e33c1d4d95afc664ad37fbdb9f6568d8043e7ea8c27d93d3"
+checksum = "65c1bf4a04a88c54f589125563643d773f3254b5c38571395e2b591c693bbc81"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "bytes"
@@ -688,33 +690,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
-name = "bytestring"
-version = "0.1.5"
+name = "bytes"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7c05fa5172da78a62d9949d662d2ac89d4cc7355d7b49adee5163f1fb3f363"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
+
+[[package]]
+name = "bytestring"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90706ba19e97b90786e19dc0d5e2abd80008d99d4c0c5d1ad0b5e72cec7c494d"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
 ]
 
 [[package]]
 name = "c2-chacha"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "217192c943108d8b13bac38a1d51df9ce8a407a3f5a71ab633980665e68fbd9a"
+checksum = "fb6b83fa00a7c53f420893670940c8fdfaa89f9dd9adb52062cca39482a31ab6"
 dependencies = [
- "byteorder",
+ "cipher",
  "ppv-lite86",
- "stream-cipher",
 ]
 
 [[package]]
 name = "cached"
-version = "0.12.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "083dc50149e37dfaab1ffe2c3af03576b79550f1e419a5091b28a7191db1c45b"
+checksum = "5e2afe73808fbaac302e39c9754bfc3c4b4d0f99c9c240b9f4e4efc841ad1b74"
 dependencies = [
+ "async-mutex",
+ "async-trait",
+ "cached_proc_macro",
+ "cached_proc_macro_types",
+ "futures",
+ "hashbrown",
  "once_cell",
 ]
+
+[[package]]
+name = "cached_proc_macro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf857ae42d910aede5c5186e62684b0d7a597ce2fe3bd14448ab8f7ef439848c"
+dependencies = [
+ "async-mutex",
+ "cached_proc_macro_types",
+ "darling",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cached_proc_macro_types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a4f925191b4367301851c6d99b09890311d74b0d43f274c0b34c86d308a3663"
 
 [[package]]
 name = "cc"
@@ -756,8 +788,17 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
- "time",
- "winapi 0.3.9",
+ "time 0.1.43",
+ "winapi",
+]
+
+[[package]]
+name = "cipher"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12f8e7987cbd042a63249497f41aed09f8e65add917ea6566effbc56578d6801"
+dependencies = [
+ "generic-array 0.14.4",
 ]
 
 [[package]]
@@ -829,15 +870,26 @@ dependencies = [
 
 [[package]]
 name = "const_fn"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd51eab21ab4fd6a3bf889e2d0958c0a6e3a61ad04260325e919e652a2a62826"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
+name = "cookie"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784ad0fbab4f3e9cef09f20e0aea6000ae08d2cb98ac4c0abc53df18803d702f"
+dependencies = [
+ "percent-encoding",
+ "time 0.2.25",
+ "version_check",
+]
 
 [[package]]
 name = "copyless"
@@ -862,22 +914,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b153fe7cbef478c567df0f972e02e6d736db11affe43dfc9c56a9374d1adfb87"
-dependencies = [
- "crossbeam-utils 0.7.2",
- "maybe-uninit",
-]
-
-[[package]]
-name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -888,7 +930,7 @@ checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
  "crossbeam-epoch",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -899,21 +941,10 @@ checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
 dependencies = [
  "cfg-if 1.0.0",
  "const_fn",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "lazy_static",
  "memoffset",
  "scopeguard",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 0.1.10",
- "lazy_static",
 ]
 
 [[package]]
@@ -945,9 +976,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.0.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8492de420e9e60bc9a1d66e2dbb91825390b738a388606600663fc529b4b307"
+checksum = "f627126b946c25a4638eec0ea634fc52506dea98db118aae985118ce7c3d723f"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -955,6 +986,47 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "darling"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d706e75d87e35569db781a9b5e2416cff1236a47ed380831f959382ccd5f858"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c960ae2da4de88a91b2d920c2a7233b400bc33cb28453a2987822d8392519b"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.9.3",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b5a2f4ac4969822c62224815d069952656cadc7084fdca9751e6d959189b72"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee2393c4a91429dffb4bedf19f4d6abf27d8a732c8ce4980305d782e5426d57"
 
 [[package]]
 name = "derive_more"
@@ -977,7 +1049,7 @@ dependencies = [
  "bitflags",
  "byteorder",
  "diesel_derives",
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
  "pq-sys",
@@ -1027,11 +1099,10 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "2.0.2"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
 dependencies = [
- "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -1043,8 +1114,14 @@ checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
+
+[[package]]
+name = "discard"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
 
 [[package]]
 name = "doc-comment"
@@ -1059,16 +1136,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
-name = "dtoa"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
 name = "dynasm"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a59fbab09460c1569eeea9b5e4cf62f13f5198b1c2ba0e5196dd7fdd17cd42"
+checksum = "3d7d1242462849390bb2ad38aeed769499f1afc7383affa2ab0c1baa894c0200"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -1081,20 +1152,20 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85bec3edae2841d37b1c3dc7f3fd403c9061f26e9ffeeee97a3ea909b1bb2ef1"
+checksum = "c1dd4d1d5ca12258cef339a57a7643e8b233a42dea9bb849630ddd9dd7726aa9"
 dependencies = [
  "byteorder",
  "dynasm",
- "memmap",
+ "memmap2",
 ]
 
 [[package]]
 name = "easy-ext"
-version = "0.2.3"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73bb6373ab18cda357d060e1cc36ca2f3fc2783a81b033087a55ac2829cfa737"
+checksum = "80581ee1c96b68c603eee514af47f075b39829304bde1a04381c826f3e06a9b4"
 dependencies = [
  "quote",
  "syn",
@@ -1140,9 +1211,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.26"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801bbab217d7f79c0062f4f7205b5d4427c6d1a7bd7aafdd1475f7c59d62b283"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
 ]
@@ -1180,7 +1251,7 @@ checksum = "fa68f2fb9cae9d37c9b2b3584aba698a2e97f72d7aef7b9f7aa71d8b54ce46fe"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1195,30 +1266,36 @@ dependencies = [
 
 [[package]]
 name = "ethbloom"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32cfe1c169414b709cf28aa30c74060bdb830a03a8ba473314d079ac79d80a5f"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
 dependencies = [
  "crunchy",
- "fixed-hash 0.5.2",
+ "fixed-hash",
  "impl-rlp",
- "impl-serde 0.2.3",
+ "impl-serde",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "ethereum-types"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba744248e3553a393143d5ebb68939fc3a4ec0c22a269682535f5ffe7fed728c"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
 dependencies = [
  "ethbloom",
- "fixed-hash 0.5.2",
+ "fixed-hash",
  "impl-rlp",
- "impl-serde 0.2.3",
- "primitive-types 0.6.2",
+ "impl-serde",
+ "primitive-types",
  "uint",
 ]
+
+[[package]]
+name = "event-listener"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7531096570974c3a9dcf9e4b8e1cede1ec26cf5046219fb3b9d897503b9be59"
 
 [[package]]
 name = "failure"
@@ -1244,33 +1321,21 @@ dependencies = [
 
 [[package]]
 name = "fixed-hash"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3367952ceb191f4ab95dd5685dc163ac539e36202f9fcfd0cb22f9f9c542fefc"
+checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
 dependencies = [
  "byteorder",
- "rand 0.7.3",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11498d382790b7a8f2fd211780bec78619bba81cdad3a283997c0c41f836759c"
-dependencies = [
- "byteorder",
- "rand 0.7.3",
+ "rand 0.8.3",
  "rustc-hex",
  "static_assertions",
 ]
 
 [[package]]
 name = "flate2"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if 1.0.0",
  "crc32fast",
@@ -1316,26 +1381,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
+name = "funty"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-dependencies = [
- "bitflags",
- "fuchsia-zircon-sys",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
 
 [[package]]
 name = "futures"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b3b0c040a1fe6529d30b3c5944b280c7f0dcb2930d2c3062bca967b602583d0"
+checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1348,9 +1403,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b7109687aa4e177ef6fe84553af6280ef2778bdb7783ba44c9dc3399110fe64"
+checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1358,15 +1413,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "847ce131b72ffb13b6109a221da9ad97a64cbe48feb1028356b836b47b8f1748"
+checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4caa2b2b68b880003057c1dd49f1ed937e38f22fcf6c212188a121f08cf40a65"
+checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1375,15 +1430,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611834ce18aaa1bd13c4b374f5d653e1027cf99b6b502584ff8c9a64413b30bb"
+checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77408a692f1f97bcc61dc001d752e00643408fbc922e4d634c655df50d595556"
+checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -1393,24 +1448,24 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f878195a49cee50e006b02b93cf7e0a95a38ac7b776b4c4d9cc1207cd20fcb3d"
+checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
 
 [[package]]
 name = "futures-task"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c554eb5bf48b2426c4771ab68c6b14468b6e76cc90996f528c3338d761a4d0d"
+checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
 dependencies = [
  "once_cell",
 ]
 
 [[package]]
 name = "futures-util"
-version = "0.3.8"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d304cff4a7b99cfb7986f7d43fbe93d175e72e704a8860787cc95e9ffd85cbd2"
+checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1419,7 +1474,7 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "memchr",
- "pin-project 1.0.2",
+ "pin-project-lite 0.2.4",
  "pin-utils",
  "proc-macro-hack",
  "proc-macro-nested",
@@ -1442,19 +1497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 
 [[package]]
-name = "generator"
-version = "0.6.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cdc09201b2e8ca1b19290cf7e65de2246b8e91fb6874279722189c4de7b94dc"
-dependencies = [
- "cc",
- "libc",
- "log",
- "rustc_version",
- "winapi 0.3.9",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,13 +1517,24 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc587bc0ec293155d5bfa6b9891ec18a1e330c234f896ea47fbada4cadbe47e6"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -1520,11 +1573,11 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "h2"
-version = "0.2.7"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e4728fd124914ad25e99e3d15a9361a879f6620f63cb56bbb08f95abb97a535"
+checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "futures-core",
  "futures-sink",
@@ -1532,8 +1585,8 @@ dependencies = [
  "http",
  "indexmap",
  "slab",
- "tokio",
- "tokio-util 0.3.1",
+ "tokio 1.1.1",
+ "tokio-util",
  "tracing",
  "tracing-futures",
 ]
@@ -1543,6 +1596,9 @@ name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash 0.4.7",
+]
 
 [[package]]
 name = "heapsize"
@@ -1550,7 +1606,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1564,9 +1620,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aca5565f760fb5b220e499d72710ed156fdb74e631659e99377d9ebfbd13ae8"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -1585,25 +1641,25 @@ checksum = "3c731c3e10504cc8ed35cfe2f1db4c9274c3d35fa486e3b31df46f068ef3e867"
 dependencies = [
  "libc",
  "match_cfg",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84129d298a6d57d246960ff8eb831ca4af3f96d29e2e28848dae275408658e26"
+checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "humantime"
@@ -1613,6 +1669,12 @@ checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
 dependencies = [
  "quick-error",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1626,36 +1688,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "if_chain"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f7280c75fb2e2fc47080ec80ccc481376923acb04501957fc38f935c3de5088"
-
-[[package]]
 name = "impl-codec"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1be51a921b067b0eaca2fad532d9400041561aa922221cc65f95a85641c6bf53"
+checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
 name = "impl-rlp"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f7a72f11830b52333f36e3b09a288333888bf54380fd0ac0790a3c31ab0f3c5"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
 dependencies = [
  "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e3cae7e99c7ff5a995da2cf78dd0a5383740eda71d98cf7b1910c301ac69b8"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -1672,6 +1719,7 @@ name = "indexer-explorer"
 version = "0.2.1"
 dependencies = [
  "actix",
+ "actix-rt",
  "base64 0.11.0",
  "bigdecimal",
  "clap 3.0.0-beta.2",
@@ -1688,7 +1736,7 @@ dependencies = [
  "r2d2",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.1.1",
  "tokio-diesel",
  "tracing",
  "tracing-subscriber",
@@ -1715,15 +1763,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "iovec"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1731,9 +1770,15 @@ checksum = "f7e2f18aece9709094573a9f24f483c4f65caa4298e2f7ae1b71cc65d853fad7"
 dependencies = [
  "socket2",
  "widestring",
- "winapi 0.3.9",
+ "winapi",
  "winreg",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
@@ -1746,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "jemalloc-sys"
@@ -1787,16 +1832,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "language-tags"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1816,9 +1851,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.81"
+version = "0.2.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1482821306169ec4d07f6aca392a4681f66c75c9918aa49641a2595db64053cb"
+checksum = "7ccac4b00700875e6a07c6cde370d44d32fa01c5a65cdd2fca6858c479d28bb3"
 
 [[package]]
 name = "libloading"
@@ -1827,7 +1862,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2b111a074963af1d37a139918ac6d49ad1d0d5e47f72fd55388619691a7d753"
 dependencies = [
  "cc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1843,9 +1878,9 @@ dependencies = [
 
 [[package]]
 name = "linked-hash-map"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+checksum = "7fb9b38af92608140b86b693604b9ffcc5824240a484d1ecd4795bacb2fe88f3"
 
 [[package]]
 name = "lock_api"
@@ -1867,24 +1902,11 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.11"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 0.1.10",
-]
-
-[[package]]
-name = "loom"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0e8460f2f2121162705187214720353c517b97bdfb3494c0b1e33d83ebe4bed"
-dependencies = [
- "cfg-if 0.1.10",
- "generator",
- "scoped-tls",
- "serde",
- "serde_json",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -1918,12 +1940,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
-name = "maybe-uninit"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
-
-[[package]]
 name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,7 +1952,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "memmap2"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e73be3b7d04a0123e933fea1d50d126cc7196bbc0362c0ce426694f777194eee"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1966,56 +1991,15 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.6.23"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4afd66f5b91bf2a3bc13fad0e21caedac168ca4c707504e75585648ae80e4cc4"
+checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
 dependencies = [
- "cfg-if 0.1.10",
- "fuchsia-zircon",
- "fuchsia-zircon-sys",
- "iovec",
- "kernel32-sys",
  "libc",
  "log",
- "miow 0.2.2",
- "net2",
- "slab",
- "winapi 0.2.8",
-]
-
-[[package]]
-name = "mio-named-pipes"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0840c1c50fd55e521b247f949c241c9997709f23bd7f023b9762cd561e935656"
-dependencies = [
- "log",
- "mio",
- "miow 0.3.6",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "mio-uds"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afcb699eb26d4332647cc848492bbc15eafb26f08d0304550d5aa1f612e066f0"
-dependencies = [
- "iovec",
- "libc",
- "mio",
-]
-
-[[package]]
-name = "miow"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebd808424166322d4a38da87083bfddd3ac4c131334ed55856112eb06d46944d"
-dependencies = [
- "kernel32-sys",
- "net2",
- "winapi 0.2.8",
- "ws2_32-sys",
+ "miow",
+ "ntapi",
+ "winapi",
 ]
 
 [[package]]
@@ -2025,21 +2009,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
 dependencies = [
  "socket2",
- "winapi 0.3.9",
-]
-
-[[package]]
-name = "near-actix-utils"
-version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
-dependencies = [
- "actix",
+ "winapi",
 ]
 
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "cached",
@@ -2049,6 +2025,7 @@ dependencies = [
  "lazy_static",
  "log",
  "near-chain-configs",
+ "near-chain-primitives",
  "near-crypto",
  "near-metrics",
  "near-pool",
@@ -2059,7 +2036,6 @@ dependencies = [
  "rocksdb",
  "serde",
  "strum",
- "strum_macros",
  "thiserror",
  "tracing",
 ]
@@ -2067,7 +2043,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2083,9 +2059,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-chain-primitives"
+version = "0.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+dependencies = [
+ "chrono",
+ "failure",
+ "failure_derive",
+ "log",
+ "near-primitives",
+]
+
+[[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "borsh",
@@ -2107,10 +2095,10 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
- "ansi_term 0.11.0",
+ "ansi_term 0.12.1",
  "borsh",
  "cached",
  "chrono",
@@ -2121,6 +2109,7 @@ dependencies = [
  "near-chain",
  "near-chain-configs",
  "near-chunks",
+ "near-client-primitives",
  "near-crypto",
  "near-metrics",
  "near-network",
@@ -2141,9 +2130,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-client-primitives"
+version = "0.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+dependencies = [
+ "actix",
+ "chrono",
+ "near-chain-primitives",
+ "near-chunks",
+ "near-network",
+ "near-primitives",
+ "serde",
+ "strum",
+ "thiserror",
+]
+
+[[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2167,18 +2172,17 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "cached",
  "log",
  "near-chain",
- "near-chain-configs",
  "near-crypto",
  "near-primitives",
  "near-store",
  "num-rational",
- "primitive-types 0.7.3",
+ "primitive-types",
  "rand 0.6.5",
  "rand 0.7.3",
  "serde",
@@ -2188,8 +2192,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.7.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+version = "0.7.1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "futures",
@@ -2199,14 +2203,14 @@ dependencies = [
  "neard",
  "node-runtime",
  "rocksdb",
- "tokio",
+ "tokio 1.1.1",
  "tracing",
 ]
 
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2218,6 +2222,7 @@ dependencies = [
  "near-client",
  "near-crypto",
  "near-jsonrpc-client",
+ "near-jsonrpc-primitives",
  "near-metrics",
  "near-network",
  "near-performance-metrics",
@@ -2227,17 +2232,18 @@ dependencies = [
  "prometheus",
  "serde",
  "serde_json",
- "tokio",
+ "tokio 1.1.1",
  "validator",
 ]
 
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix-web",
  "futures",
+ "near-jsonrpc-primitives",
  "near-primitives",
  "serde",
  "serde_json",
@@ -2245,9 +2251,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-jsonrpc-primitives"
+version = "0.1.0"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
+dependencies = [
+ "actix",
+ "lazy_static",
+ "near-client-primitives",
+ "near-metrics",
+ "near-primitives",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uuid",
+]
+
+[[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "lazy_static",
  "log",
@@ -2257,12 +2279,12 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "borsh",
  "byteorder",
- "bytes",
+ "bytes 1.0.1",
  "cached",
  "chrono",
  "futures",
@@ -2280,27 +2302,31 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "tokio",
- "tokio-util 0.2.0",
+ "tokio 1.1.1",
+ "tokio-stream",
+ "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "near-performance-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "actix-rt",
  "futures",
  "log",
+ "near-rust-allocator-proxy",
+ "nix",
  "once_cell",
+ "strum",
 ]
 
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "quote",
  "syn",
@@ -2309,7 +2335,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2320,9 +2346,9 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.13.0",
  "borsh",
  "bs58",
  "byteorder",
@@ -2336,7 +2362,7 @@ dependencies = [
  "near-rpc-error-macro",
  "near-vm-errors",
  "num-rational",
- "primitive-types 0.7.3",
+ "primitive-types",
  "rand 0.7.3",
  "reed-solomon-erasure",
  "regex",
@@ -2345,13 +2371,12 @@ dependencies = [
  "sha2",
  "smart-default",
  "validator",
- "validator_derive",
 ]
 
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2362,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2375,8 +2400,9 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
+ "lazy_static",
  "near-primitives",
  "near-runtime-fees",
  "near-vm-logic",
@@ -2386,7 +2412,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-fees"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "num-rational",
  "serde",
@@ -2395,16 +2421,31 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "lazy_static",
  "regex",
 ]
 
 [[package]]
+name = "near-rust-allocator-proxy"
+version = "0.2.6"
+source = "git+https://github.com/near/near-memory-tracker.git?tag=v0.2.6#567647c4987d4f04910ab47e00f427c0c1bf3bf6"
+dependencies = [
+ "arr_macro",
+ "backtrace",
+ "jemalloc-sys",
+ "jemallocator",
+ "libc",
+ "log",
+ "nix",
+ "rand 0.7.3",
+]
+
+[[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2420,13 +2461,12 @@ dependencies = [
  "serde",
  "serde_json",
  "strum",
- "strum_macros",
 ]
 
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "actix-web",
@@ -2442,7 +2482,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "ethereum-types",
@@ -2454,15 +2494,16 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
- "base64 0.11.0",
+ "base64 0.13.0",
  "borsh",
  "bs58",
  "byteorder",
  "near-runtime-fees",
  "near-runtime-utils",
  "near-vm-errors",
+ "num-rational",
  "serde",
  "sha2",
  "sha3",
@@ -2471,9 +2512,10 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
+ "cached",
  "log",
  "near-primitives",
  "near-runtime-fees",
@@ -2487,8 +2529,8 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+version = "1.18.0-rc.1"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "actix",
  "actix-web",
@@ -2500,9 +2542,9 @@ dependencies = [
  "easy-ext",
  "futures",
  "git-version",
+ "jemallocator",
  "lazy_static",
  "log",
- "near-actix-utils",
  "near-chain",
  "near-chain-configs",
  "near-chunks",
@@ -2515,6 +2557,7 @@ dependencies = [
  "near-pool",
  "near-primitives",
  "near-runtime-configs",
+ "near-rust-allocator-proxy",
  "near-store",
  "near-telemetry",
  "node-runtime",
@@ -2526,17 +2569,6 @@ dependencies = [
  "serde_json",
  "tracing",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "net2"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "391630d12b68002ae1e25e8f974306474966550ad82dac6886fb8910c19568ae"
-dependencies = [
- "cfg-if 0.1.10",
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2555,7 +2587,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=29fcaf3b8c81a4c0371d105054ce251355382a77#29fcaf3b8c81a4c0371d105054ce251355382a77"
+source = "git+https://github.com/nearprotocol/nearcore?rev=fd02f02fbab6d258e2f4abc27f26d2be9a560af1#fd02f02fbab6d258e2f4abc27f26d2be9a560af1"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2573,7 +2605,7 @@ dependencies = [
  "near-vm-errors",
  "near-vm-logic",
  "near-vm-runner",
- "num-bigint",
+ "num-bigint 0.3.1",
  "num-rational",
  "num-traits",
  "rand 0.7.3",
@@ -2598,7 +2630,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2606,6 +2638,17 @@ name = "num-bigint"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
+dependencies = [
+ "autocfg 1.0.1",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e9a41747ae4633fce5adffb4d2e81ffc5e89593cb19917f8fb2cc5ff76507bf"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -2624,12 +2667,12 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "12ac428b1cb17fce6f731001d307d351ec70a6d202fc2e60f7d4c5e42d8f4f07"
 dependencies = [
  "autocfg 1.0.1",
- "num-bigint",
+ "num-bigint 0.3.1",
  "num-integer",
  "num-traits",
  "serde",
@@ -2656,9 +2699,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.22.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d3b63360ec3cb337817c2dbd47ab4a0f170d285d8e5a2064600f3def1402397"
+checksum = "a9a7ab5d64814df0fe4a4b5ead45ed6c5f181ee3ff04ba344313a6c80446c5d4"
 
 [[package]]
 name = "once_cell"
@@ -2674,9 +2717,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.31"
+version = "0.10.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d008f51b1acffa0d3450a68606e6a51c123012edaacb0f4e1426bd978869187"
+checksum = "038d43985d1ddca7a9900630d8cd031b56e4794eecc2e9ea39dd17aa04399a70"
 dependencies = [
  "bitflags",
  "cfg-if 1.0.0",
@@ -2703,9 +2746,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.59"
+version = "0.9.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de52d8eabd217311538a39bba130d7dea1f1e118010fee7a033d966845e7d5fe"
+checksum = "921fc71883267538946025deffb622905ecad223c28efbfdef9bb59a0175f3e6"
 dependencies = [
  "autocfg 1.0.1",
  "cc",
@@ -2728,14 +2771,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
 name = "parity-scale-codec"
-version = "1.3.5"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c740e5fbcb6847058b40ac7e5574766c6388f585e184d769910fe0d3a2ca861"
+checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -2793,7 +2836,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2807,7 +2850,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2833,11 +2876,11 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccc2237c2c489783abd8c4c80e5450fc0e98644555b1364da68cc29aa151ca7"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 1.0.2",
+ "pin-project-internal 1.0.5",
 ]
 
 [[package]]
@@ -2853,9 +2896,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.2"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e8d2bf0b23038a4424865103a4df472855692821aab4e4f5c3312d461d9e5f"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2870,9 +2913,9 @@ checksum = "c917123afa01924fc84bb20c4c03f004d9c38e5127e3c039bbf7f4b9c76a2f6b"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.0"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b063f57ec186e6140e2b8b6921e5f1bd89c7356dda5b33acc5401203ca6131c"
+checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
 
 [[package]]
 name = "pin-utils"
@@ -2903,26 +2946,24 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.6.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4336f4f5d5524fa60bcbd6fe626f9223d8142a50e7053e979acdf0da41ab975"
+checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
 dependencies = [
- "fixed-hash 0.5.2",
+ "fixed-hash",
  "impl-codec",
  "impl-rlp",
- "impl-serde 0.3.1",
+ "impl-serde",
  "uint",
 ]
 
 [[package]]
-name = "primitive-types"
-version = "0.7.3"
+name = "proc-macro-crate"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd39dcacf71411ba488570da7bbc89b717225e46478b30ba99b92db6b149809"
+checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "fixed-hash 0.6.1",
- "impl-codec",
- "uint",
+ "toml",
 ]
 
 [[package]]
@@ -2957,9 +2998,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro-nested"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
+checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
@@ -2972,23 +3013,24 @@ dependencies = [
 
 [[package]]
 name = "prometheus"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0575e258dab62268e7236d7307caa38848acbda7ec7ab87bd9093791e999d20"
+checksum = "c8425533e7122f0c3cc7a37e6244b16ad3a2cc32ae7ac6276e2a75da0d9c200d"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
+ "parking_lot 0.11.1",
  "protobuf",
- "spin",
+ "regex",
  "thiserror",
 ]
 
 [[package]]
 name = "protobuf"
-version = "2.18.1"
+version = "2.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da78e04bc0e40f36df43ecc6575e4f4b180e8156c4efd73f13d5619479b05696"
+checksum = "86473d5f16580f10b131a0bf0afb68f8e029d1835d33a00f37281b05694e5312"
 
 [[package]]
 name = "pwasm-utils"
@@ -3029,9 +3071,9 @@ dependencies = [
 
 [[package]]
 name = "radium"
-version = "0.3.0"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "def50a86306165861203e7f84ecffbbdfdea79f0e51039b33de1e952358c47ac"
+checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
 
 [[package]]
 name = "rand"
@@ -3048,7 +3090,7 @@ dependencies = [
  "rand_jitter",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3057,11 +3099,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -3085,6 +3139,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3105,7 +3169,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -3127,6 +3200,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
+]
+
+[[package]]
 name = "rand_isaac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3143,7 +3225,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3183,9 +3265,9 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
 dependencies = [
- "crossbeam-channel 0.5.0",
+ "crossbeam-channel",
  "crossbeam-deque",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
  "lazy_static",
  "num_cpus",
 ]
@@ -3202,7 +3284,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -3218,9 +3300,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cf2c13ed4745de91a5eb834e11c00bcc3709e773173b2ce4c56c9fbde04b9c"
+checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3240,15 +3322,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.21"
+version = "0.6.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b181ba2dcf07aaccad5448e8ead58db5b742cf85dfe035e2227f137a539a189"
+checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "resolv-conf"
-version = "0.6.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11834e137f3b14e309437a8276714eed3a80d1ef894869e510f2c0c0b98b9f4a"
+checksum = "52e44394d2086d010551b14b53b1f24e31647570cd1deb0379e2c21b329aba00"
 dependencies = [
  "hostname",
  "quick-error",
@@ -3256,10 +3338,11 @@ dependencies = [
 
 [[package]]
 name = "rlp"
-version = "0.4.6"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1190dcc8c3a512f1eef5d09bb8c84c7f39e1054e174d1795482e18f5272f2e73"
+checksum = "e54369147e3e7796c9b885c7304db87ca3d09a0a98f72843d532868675bbfba8"
 dependencies = [
+ "bytes 1.0.1",
  "rustc-hex",
 ]
 
@@ -3281,7 +3364,7 @@ dependencies = [
  "base64 0.13.0",
  "blake2b_simd",
  "constant_time_eq",
- "crossbeam-utils 0.8.1",
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -3327,12 +3410,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,9 +3432,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
+checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
 dependencies = [
  "serde_derive",
 ]
@@ -3383,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.118"
+version = "1.0.123"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c84d3526699cd55261af4b941e4e725444df67aa4f9e6a3564f18030d12672df"
+checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3394,9 +3471,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1500e84d27fe482ed1dc791a56eddc2f230046a040fa908c08bda1d9fb615779"
+checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3406,14 +3483,27 @@ dependencies = [
 
 [[package]]
 name = "serde_urlencoded"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ec5d77e2d4c73717816afac02670d5c4f534ea95ed430442cad02e7a6e32c97"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
 dependencies = [
- "dtoa",
+ "form_urlencoded",
  "itoa",
+ "ryu",
  "serde",
- "url",
+]
+
+[[package]]
+name = "sha-1"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4b312c3731e3fe78a185e6b9b911a7aa715b8e31cce117975219aab2acf285d"
+dependencies = [
+ "block-buffer",
+ "cfg-if 1.0.0",
+ "cpuid-bool",
+ "digest 0.9.0",
+ "opaque-debug",
 ]
 
 [[package]]
@@ -3424,9 +3514,9 @@ checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sha2"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e7aab86fe2149bad8c507606bdb3f4ef5e7b2380eb92350f56122cca72a42a8"
+checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
 dependencies = [
  "block-buffer",
  "cfg-if 1.0.0",
@@ -3449,12 +3539,11 @@ dependencies = [
 
 [[package]]
 name = "sharded-slab"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4921be914e16899a80adefb821f8ddb7974e3f1250223575a44ed994882127"
+checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
- "loom",
 ]
 
 [[package]]
@@ -3474,9 +3563,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29f060a7d147e33490ec10da418795238fd7545bba241504d6b31a409f2e6210"
+checksum = "0f0242b8e50dd9accdd56170e94ca1ebd223b098eb9c83539a6e367d0f36ae68"
 
 [[package]]
 name = "slab"
@@ -3486,9 +3575,9 @@ checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "smallvec"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae524f056d7d770e174287294f562e95044c68e88dec909a00d2094805db9d75"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "smart-default"
@@ -3509,14 +3598,17 @@ checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
-name = "spin"
-version = "0.5.2"
+name = "standback"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+checksum = "c66a8cff4fa24853fdf6b51f75c6d7f8206d7c75cab4e467bcd7f25c2b1febe0"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "static_assertions"
@@ -3525,13 +3617,53 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
-name = "stream-cipher"
-version = "0.3.2"
+name = "stdweb"
+version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+checksum = "d022496b16281348b52d0e30ae99e01a73d737b2f45d38fed4edf79f9325a1d5"
 dependencies = [
- "generic-array 0.12.3",
+ "discard",
+ "rustc_version",
+ "stdweb-derive",
+ "stdweb-internal-macros",
+ "stdweb-internal-runtime",
+ "wasm-bindgen",
 ]
+
+[[package]]
+name = "stdweb-derive"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87a60a40fccc84bef0652345bbbbbe20a605bf5d0ce81719fc476f5c03b50ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58fa5ff6ad0d98d1ffa8cb115892b6e69d67799f6763e162a1c9db421dc22e11"
+dependencies = [
+ "base-x",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "sha1",
+ "syn",
+]
+
+[[package]]
+name = "stdweb-internal-runtime"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "strsim"
@@ -3541,24 +3673,30 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
+
+[[package]]
+name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.18.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bd81eb48f4c437cadc685403cad539345bf703d78e63707418431cecd4522b"
+checksum = "7318c509b5ba57f18533982607f24070a55d353e90d4cae30c467cdb2ad5ac5c"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.18.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87c85aa3f8ea653bfd3ddf25f7ee357ee4d204731f6aa9ad04002306f6e2774c"
+checksum = "ee8bc6b87a5112aeeab1f4a9f7ab634fe6cbefc4850006df31267f4cfb9e3149"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3574,9 +3712,9 @@ checksum = "1e81da0851ada1f3e9d4312c704aa4f8806f0f9d69faaf8df2f3464b4a9437c2"
 
 [[package]]
 name = "syn"
-version = "1.0.55"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a571a711dddd09019ccc628e1b17fe87c59b09d513c06c026877aa708334f37a"
+checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3606,8 +3744,14 @@ dependencies = [
  "ntapi",
  "once_cell",
  "rayon",
- "winapi 0.3.9",
+ "winapi",
 ]
+
+[[package]]
+name = "tap"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36474e732d1affd3a6ed582781b3683df3d0563714c59c39591e8ff707cf078e"
 
 [[package]]
 name = "target-lexicon"
@@ -3644,18 +3788,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3664,11 +3808,11 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.0.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
 dependencies = [
- "lazy_static",
+ "once_cell",
 ]
 
 [[package]]
@@ -3682,29 +3826,66 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.44"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9e6914ab8b1ae1c260a4ae7a49b6c5611b40328a735b21862567685e73255"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi 0.3.9",
+ "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1195b046942c221454c2539395f85413b33383a067449d78aab2b7b052a142f7"
+dependencies = [
+ "const_fn",
+ "libc",
+ "standback",
+ "stdweb",
+ "time-macros",
+ "version_check",
+ "winapi",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957e9c6e26f12cb6d0dd7fc776bb67a706312e7299aed74c8dd5b17ebb27e2f1"
+dependencies = [
+ "proc-macro-hack",
+ "time-macros-impl",
+]
+
+[[package]]
+name = "time-macros-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5c3be1edfad6027c69f5491cf4cb310d1a71ecd6af742788c6ff8bced86b8fa"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "standback",
+ "syn",
 ]
 
 [[package]]
 name = "tiny-keccak"
-version = "1.5.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
 dependencies = [
  "crunchy",
 ]
 
 [[package]]
 name = "tinyvec"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3717,26 +3898,33 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "0.2.24"
+version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099837d3464c16a808060bb3f02263b412f6fafcb5d01c533d309985fbeebe48"
+checksum = "6703a273949a90131b290be1fe7b039d0fc884aa1935860dfcbe056f28cd8092"
 dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "iovec",
- "lazy_static",
+ "bytes 0.5.6",
+ "pin-project-lite 0.1.11",
+ "slab",
+]
+
+[[package]]
+name = "tokio"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6714d663090b6b0acb0fa85841c6d66233d150cdb2602c8f9b8abb03370beb3f"
+dependencies = [
+ "autocfg 1.0.1",
+ "bytes 1.0.1",
  "libc",
  "memchr",
  "mio",
- "mio-named-pipes",
- "mio-uds",
  "num_cpus",
- "pin-project-lite 0.1.11",
+ "once_cell",
+ "parking_lot 0.11.1",
+ "pin-project-lite 0.2.4",
  "signal-hook-registry",
- "slab",
  "tokio-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3749,14 +3937,14 @@ dependencies = [
  "diesel",
  "futures",
  "r2d2",
- "tokio",
+ "tokio 0.2.25",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "0.2.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e44da00bfc73a25f814cd8d7e57a68a5c31b74b3152a0a1d1f590c97ed06265a"
+checksum = "42517d2975ca3114b22a16192634e8241dc5cc1f130be194645970cc1c371494"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3765,40 +3953,50 @@ dependencies = [
 
 [[package]]
 name = "tokio-openssl"
-version = "0.4.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4b08c5f4208e699ede3df2520aca2e82401b2de33f45e96696a074480be594"
+checksum = "ac1bec5c0a4aa71e3459802c7a12e8912c2091ce2151004f9ce95cc5d1c6124e"
 dependencies = [
+ "futures",
  "openssl",
- "tokio",
+ "pin-project 1.0.5",
+ "tokio 1.1.1",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+dependencies = [
+ "futures-core",
+ "pin-project-lite 0.2.4",
+ "tokio 1.1.1",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.2.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "571da51182ec208780505a32528fc5512a8fe1443ab960b3f2f3ef093cd16930"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "bytes",
+ "bytes 1.0.1",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "log",
- "pin-project-lite 0.1.11",
- "tokio",
+ "pin-project-lite 0.2.4",
+ "slab",
+ "tokio 1.1.1",
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.3.1"
+name = "toml"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8242891f2b6cbef26a2d7e8605133c2c554cd35b3e4948ea892d6d68436499"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
 dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite 0.1.11",
- "tokio",
+ "serde",
 ]
 
 [[package]]
@@ -3808,8 +4006,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
 dependencies = [
  "cfg-if 1.0.0",
- "log",
- "pin-project-lite 0.2.0",
+ "pin-project-lite 0.2.4",
  "tracing-attributes",
  "tracing-core",
 ]
@@ -3889,40 +4086,45 @@ dependencies = [
 
 [[package]]
 name = "trust-dns-proto"
-version = "0.18.0-alpha.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a7f3a2ab8a919f5eca52a468866a67ed7d3efa265d48a652a9a3452272b413f"
+checksum = "98a0381b2864c2978db7f8e17c7b23cca5a3a5f99241076e13002261a8ecbabd"
 dependencies = [
  "async-trait",
+ "cfg-if 1.0.0",
+ "data-encoding",
  "enum-as-inner",
- "failure",
- "futures",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
  "idna",
+ "ipnet",
  "lazy_static",
  "log",
- "rand 0.7.3",
+ "rand 0.8.3",
  "smallvec",
- "socket2",
- "tokio",
+ "thiserror",
+ "tokio 1.1.1",
  "url",
 ]
 
 [[package]]
 name = "trust-dns-resolver"
-version = "0.18.0-alpha.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f90b1502b226f8b2514c6d5b37bafa8c200d7ca4102d57dc36ee0f3b7a04a2f"
+checksum = "3072d18c10bd621cb00507d59cfab5517862285c353160366e37fbf4c74856e4"
 dependencies = [
- "cfg-if 0.1.10",
- "failure",
- "futures",
+ "cfg-if 1.0.0",
+ "futures-util",
  "ipconfig",
  "lazy_static",
  "log",
  "lru-cache",
+ "parking_lot 0.11.1",
  "resolv-conf",
  "smallvec",
- "tokio",
+ "thiserror",
+ "tokio 1.1.1",
  "trust-dns-proto",
 ]
 
@@ -3934,13 +4136,13 @@ checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "uint"
-version = "0.8.5"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db035e67dfaf7edd9aebfe8676afcd63eed53c8a4044fed514c8cccf1835177"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "rustc-hex",
+ "hex",
  "static_assertions",
 ]
 
@@ -3994,18 +4196,18 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fde2f6a4bea1d6e007c4ad38c6839fa71cbb63b6dbf5b595aa38dc9b1093c11"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
 dependencies = [
- "rand 0.7.3",
+ "getrandom 0.2.2",
 ]
 
 [[package]]
 name = "validator"
-version = "0.10.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e60fadf92c22236de4028ceb0b8af50ed3430d41ad43d7a7d63b6bd1a8f47c38"
+checksum = "841d6937c33ec6039d8071bcf72933146b5bbe378d645d8fa59bdadabfc2a249"
 dependencies = [
  "idna",
  "lazy_static",
@@ -4014,22 +4216,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "url",
+ "validator_types",
 ]
 
 [[package]]
-name = "validator_derive"
-version = "0.10.1"
+name = "validator_types"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d577dfb8ca9440a5c0b053d5a19b68f5c92ef57064bac87c8205c3f6072c20f"
-dependencies = [
- "if_chain",
- "lazy_static",
- "proc-macro2",
- "quote",
- "regex",
- "syn",
- "validator",
-]
+checksum = "ad9680608df133af2c1ddd5eaf1ddce91d60d61b6bc51494ef326458365a470a"
 
 [[package]]
 name = "vcpkg"
@@ -4063,9 +4257,63 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
 
 [[package]]
 name = "wasmer-runtime-core-near"
@@ -4093,7 +4341,7 @@ dependencies = [
  "smallvec",
  "target-lexicon",
  "wasmparser",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4152,12 +4400,6 @@ checksum = "c168940144dd21fd8046987c16a46a33d5fc84eec29ef9dcddc2ac9e31526b7c"
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -4165,12 +4407,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -4184,7 +4420,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -4199,18 +4435,14 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2986deb581c4fe11b621998a5e53361efe6b48a151178d0cd9eeffa4dc6acc9"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
-name = "ws2_32-sys"
-version = "0.2.1"
+name = "wyz"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
+checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
 
 [[package]]
 name = "zeroize"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1716,7 +1716,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "actix",
  "actix-rt",
@@ -1738,6 +1738,7 @@ dependencies = [
  "serde_json",
  "tokio 1.1.1",
  "tokio-diesel",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-diesel"
+version = "0.3.1-alpha.0"
+source = "git+https://github.com/frol/actix-diesel?branch=actix-0.11-beta#f902c2a470c3474c63184c842cbc4b930b000ead"
+dependencies = [
+ "actix",
+ "actix-rt",
+ "derive_more",
+ "diesel",
+ "futures",
+ "num_cpus",
+ "once_cell",
+ "r2d2",
+]
+
+[[package]]
 name = "actix-http"
 version = "3.0.0-beta.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1713,6 +1728,7 @@ name = "indexer-explorer"
 version = "0.2.3"
 dependencies = [
  "actix",
+ "actix-diesel",
  "actix-rt",
  "base64 0.11.0",
  "bigdecimal",
@@ -1731,7 +1747,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-diesel",
  "tokio-stream",
  "tracing",
  "tracing-subscriber",
@@ -2010,7 +2025,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "cached",
@@ -2038,7 +2053,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2056,7 +2071,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "chrono",
  "failure",
@@ -2068,7 +2083,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "borsh",
@@ -2090,7 +2105,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "ansi_term 0.12.1",
@@ -2127,7 +2142,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "chrono",
@@ -2143,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2167,7 +2182,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "cached",
@@ -2188,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.8.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "futures",
@@ -2205,7 +2220,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2234,7 +2249,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix-web",
  "futures",
@@ -2248,7 +2263,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "lazy_static",
@@ -2264,7 +2279,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "lazy_static",
  "log",
@@ -2274,7 +2289,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "borsh",
@@ -2306,7 +2321,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2321,7 +2336,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "quote",
  "syn",
@@ -2330,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2341,7 +2356,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2371,7 +2386,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2382,7 +2397,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2395,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-configs"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "lazy_static",
  "near-primitives",
@@ -2407,7 +2422,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-fees"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "num-rational",
  "serde",
@@ -2416,7 +2431,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2440,7 +2455,7 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2461,7 +2476,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "actix-web",
@@ -2477,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "ethereum-types",
@@ -2489,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2507,7 +2522,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "cached",
@@ -2525,7 +2540,7 @@ dependencies = [
 [[package]]
 name = "neard"
 version = "1.2.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "actix",
  "actix-web",
@@ -2582,7 +2597,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "2.3.0"
-source = "git+https://github.com/nearprotocol/nearcore?rev=c2b6ee64eabacaeb4a4c64a06f7025c51722517c#c2b6ee64eabacaeb4a4c64a06f7025c51722517c"
+source = "git+https://github.com/near/nearcore?rev=f31cfb954bdd81885bc789bfa406035717db5ab5#f31cfb954bdd81885bc789bfa406035717db5ab5"
 dependencies = [
  "borsh",
  "byteorder",
@@ -3903,18 +3918,6 @@ dependencies = [
  "signal-hook-registry",
  "tokio-macros",
  "winapi",
-]
-
-[[package]]
-name = "tokio-diesel"
-version = "0.3.0"
-source = "git+https://github.com/mehcode/tokio-diesel?rev=f4af42558246ab323600622ba8d08803d3c18842#f4af42558246ab323600622ba8d08803d3c18842"
-dependencies = [
- "async-trait",
- "diesel",
- "futures",
- "r2d2",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,9 +26,9 @@ tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-tokio-diesel = { git = "https://github.com/mehcode/tokio-diesel", rev = "f4af42558246ab323600622ba8d08803d3c18842"}
-near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="c2b6ee64eabacaeb4a4c64a06f7025c51722517c" }
-near-crypto = { git = "https://github.com/nearprotocol/nearcore", rev="c2b6ee64eabacaeb4a4c64a06f7025c51722517c" }
+actix-diesel = { git = "https://github.com/frol/actix-diesel", branch="actix-0.11-beta" }
+near-indexer = { git = "https://github.com/near/nearcore", rev="f31cfb954bdd81885bc789bfa406035717db5ab5" }
+near-crypto = { git = "https://github.com/near/nearcore", rev="f31cfb954bdd81885bc789bfa406035717db5ab5" }
 
 [dev-dependencies]
 # Pin dependency to avoid compilation errors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "indexer-explorer"
-version = "0.2.1"
+version = "0.2.3"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
 [dependencies]
-actix = "0.9"
+actix = "0.11.0-beta.1"
 base64 = "0.11"
 bigdecimal = "=0.1.0"
 clap = "3.0.0-beta.1"
@@ -21,10 +21,14 @@ openssl-probe = { version = "0.1.2" }
 r2d2 = "0.8.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
-tokio = { version = "0.2", features = ["sync", "time"] }
+tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-diesel = "0.3.0"
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="29fcaf3b8c81a4c0371d105054ce251355382a77" }
-near-crypto = { git = "https://github.com/nearprotocol/nearcore", rev="29fcaf3b8c81a4c0371d105054ce251355382a77" }
+near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="fd02f02fbab6d258e2f4abc27f26d2be9a560af1" }
+near-crypto = { git = "https://github.com/nearprotocol/nearcore", rev="fd02f02fbab6d258e2f4abc27f26d2be9a560af1" }
+
+[dev-dependencies]
+# Pin dependency to avoid compilation errors
+actix-rt = "=2.0.0-beta.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time"] }
 tokio-diesel = "0.3.0"
+tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,13 +22,13 @@ r2d2 = "0.8.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.55"
 tokio = { version = "1.1", features = ["sync", "time"] }
-tokio-diesel = "0.3.0"
 tokio-stream = { version = "0.1" }
 tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
-near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="fd02f02fbab6d258e2f4abc27f26d2be9a560af1" }
-near-crypto = { git = "https://github.com/nearprotocol/nearcore", rev="fd02f02fbab6d258e2f4abc27f26d2be9a560af1" }
+tokio-diesel = { git = "https://github.com/mehcode/tokio-diesel", rev = "f4af42558246ab323600622ba8d08803d3c18842"}
+near-indexer = { git = "https://github.com/nearprotocol/nearcore", rev="c2b6ee64eabacaeb4a4c64a06f7025c51722517c" }
+near-crypto = { git = "https://github.com/nearprotocol/nearcore", rev="c2b6ee64eabacaeb4a4c64a06f7025c51722517c" }
 
 [dev-dependencies]
 # Pin dependency to avoid compilation errors

--- a/src/db_adapters/access_keys.rs
+++ b/src/db_adapters/access_keys.rs
@@ -155,7 +155,7 @@ pub(crate) async fn handle_access_keys(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -195,7 +195,7 @@ pub(crate) async fn handle_access_keys(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -222,7 +222,7 @@ pub(crate) async fn handle_access_keys(
                         interval.as_millis(),
                         async_error,
                     );
-                    tokio::time::delay_for(interval).await;
+                    tokio::time::sleep(interval).await;
                     if interval < crate::MAX_DELAY_TIME {
                         interval *= 2;
                     }
@@ -261,7 +261,7 @@ pub(crate) async fn handle_access_keys(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -334,7 +334,7 @@ pub(crate) async fn store_access_keys_from_genesis(near_config: near_indexer::Ne
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }

--- a/src/db_adapters/access_keys.rs
+++ b/src/db_adapters/access_keys.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 
 use bigdecimal::BigDecimal;
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::{ExpressionMethods, PgConnection, QueryDsl};
 use futures::{join, StreamExt};
 use itertools::Itertools;
-use tokio_diesel::AsyncRunQueryDsl;
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use tracing::{error, info};
 
 use near_indexer::near_primitives;
@@ -15,7 +14,7 @@ use crate::models;
 use crate::schema;
 
 pub(crate) async fn handle_access_keys(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     outcomes: &[near_indexer::IndexerExecutionOutcomeWithReceipt],
     block_height: near_primitives::types::BlockHeight,
 ) {

--- a/src/db_adapters/account_changes.rs
+++ b/src/db_adapters/account_changes.rs
@@ -1,6 +1,5 @@
-use diesel::r2d2::{ConnectionManager, Pool};
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use diesel::PgConnection;
-use tokio_diesel::AsyncRunQueryDsl;
 use tracing::error;
 
 use crate::models;
@@ -8,7 +7,7 @@ use crate::schema;
 
 /// Saves state change related to account to database
 pub(crate) async fn store_account_changes(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     state_changes: &[near_indexer::near_primitives::views::StateChangeWithCauseView],
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
     block_timestamp: u64,

--- a/src/db_adapters/account_changes.rs
+++ b/src/db_adapters/account_changes.rs
@@ -45,7 +45,7 @@ pub(crate) async fn store_account_changes(
                     async_error,
                     &account_changes_models
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/db_adapters/accounts.rs
+++ b/src/db_adapters/accounts.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
 
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::{ExpressionMethods, PgConnection, QueryDsl};
 use futures::{join, StreamExt};
 use itertools::Itertools;
-use tokio_diesel::AsyncRunQueryDsl;
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use tracing::{error, info};
 
 use near_indexer::near_primitives;
@@ -14,7 +13,7 @@ use crate::schema;
 
 /// Saves new Accounts to database or deletes the ones should be deleted
 pub(crate) async fn handle_accounts(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     outcomes: &[near_indexer::IndexerExecutionOutcomeWithReceipt],
     block_height: near_primitives::types::BlockHeight,
 ) {

--- a/src/db_adapters/accounts.rs
+++ b/src/db_adapters/accounts.rs
@@ -118,7 +118,7 @@ pub(crate) async fn handle_accounts(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -145,7 +145,7 @@ pub(crate) async fn handle_accounts(
                         interval.as_millis(),
                         async_error,
                     );
-                    tokio::time::delay_for(interval).await;
+                    tokio::time::sleep(interval).await;
                     if interval < crate::MAX_DELAY_TIME {
                         interval *= 2;
                     }
@@ -183,7 +183,7 @@ pub(crate) async fn handle_accounts(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -250,7 +250,7 @@ pub(crate) async fn store_accounts_from_genesis(near_config: near_indexer::NearC
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }

--- a/src/db_adapters/blocks.rs
+++ b/src/db_adapters/blocks.rs
@@ -1,6 +1,5 @@
-use diesel::r2d2::{ConnectionManager, Pool};
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use diesel::PgConnection;
-use tokio_diesel::AsyncRunQueryDsl;
 use tracing::error;
 
 use near_indexer::near_primitives;
@@ -10,7 +9,7 @@ use crate::schema;
 
 /// Saves block to database
 pub(crate) async fn store_block(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     block: &near_primitives::views::BlockView,
 ) {
     let block_model = models::blocks::Block::from(block);

--- a/src/db_adapters/blocks.rs
+++ b/src/db_adapters/blocks.rs
@@ -32,7 +32,7 @@ pub(crate) async fn store_block(
                     async_error,
                     &block_model
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/db_adapters/chunks.rs
+++ b/src/db_adapters/chunks.rs
@@ -37,7 +37,7 @@ pub(crate) async fn store_chunks(
                     async_error,
                     &chunk_models
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/db_adapters/chunks.rs
+++ b/src/db_adapters/chunks.rs
@@ -1,6 +1,5 @@
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::PgConnection;
-use tokio_diesel::AsyncRunQueryDsl;
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use tracing::error;
 
 use crate::models;
@@ -8,7 +7,7 @@ use crate::schema;
 
 /// Saves chunks to database
 pub(crate) async fn store_chunks(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     chunks: &[near_indexer::IndexerChunkView],
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
 ) {

--- a/src/db_adapters/execution_outcomes.rs
+++ b/src/db_adapters/execution_outcomes.rs
@@ -1,6 +1,5 @@
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::{ExpressionMethods, PgConnection, QueryDsl};
-use tokio_diesel::AsyncRunQueryDsl;
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use tracing::error;
 
 use crate::models;
@@ -8,7 +7,7 @@ use crate::schema;
 use diesel::pg::expression::array_comparison::any;
 
 pub(crate) async fn store_execution_outcomes(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     chunks: &[near_indexer::IndexerChunkView],
     block_timestamp: u64,
 ) {
@@ -25,7 +24,7 @@ pub(crate) async fn store_execution_outcomes(
 
 /// Saves ExecutionOutcome to database and then saves ExecutionOutcomesReceipts
 pub async fn store_execution_outcomes_for_chunk(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     execution_outcomes: &[near_indexer::IndexerExecutionOutcomeWithReceipt],
     chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
     block_timestamp: u64,

--- a/src/db_adapters/execution_outcomes.rs
+++ b/src/db_adapters/execution_outcomes.rs
@@ -53,7 +53,7 @@ pub async fn store_execution_outcomes_for_chunk(
                     interval.as_millis(),
                     async_error,
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -111,7 +111,7 @@ pub async fn store_execution_outcomes_for_chunk(
                     async_error,
                     &outcome_models,
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -136,7 +136,7 @@ pub async fn store_execution_outcomes_for_chunk(
                     async_error,
                     &outcome_receipt_models
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -131,7 +131,7 @@ async fn find_tx_hashes_for_receipts(
                             interval.as_millis(),
                             async_error,
                         );
-                        tokio::time::delay_for(interval).await;
+                        tokio::time::sleep(interval).await;
                         if interval < crate::MAX_DELAY_TIME {
                             interval *= 2;
                         }
@@ -210,7 +210,7 @@ async fn find_tx_hashes_for_receipts(
                         interval.as_millis(),
                         async_error,
                     );
-                    tokio::time::delay_for(interval).await;
+                    tokio::time::sleep(interval).await;
                     if interval < crate::MAX_DELAY_TIME {
                         interval *= 2;
                     }
@@ -254,7 +254,7 @@ async fn find_tx_hashes_for_receipts(
                         interval.as_millis(),
                         async_error,
                     );
-                    tokio::time::delay_for(interval).await;
+                    tokio::time::sleep(interval).await;
                     if interval < crate::MAX_DELAY_TIME {
                         interval *= 2;
                     }
@@ -287,7 +287,7 @@ async fn find_tx_hashes_for_receipts(
             block_hash,
             chunk_hash
         );
-        tokio::time::delay_for(find_tx_retry_interval).await;
+        tokio::time::sleep(find_tx_retry_interval).await;
         if find_tx_retry_interval < crate::MAX_DELAY_TIME {
             find_tx_retry_interval *= 2;
         }
@@ -317,7 +317,7 @@ async fn save_receipts(
                     async_error,
                     receipts,
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -415,7 +415,7 @@ async fn store_receipt_actions(
                     async_error,
                     &receipt_actions,
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -440,7 +440,7 @@ async fn store_receipt_actions(
                     async_error,
                     &receipt_action_actions
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -465,7 +465,7 @@ async fn store_receipt_actions(
                     async_error,
                     &receipt_action_output_data
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -490,7 +490,7 @@ async fn store_receipt_actions(
                     async_error,
                     &receipt_action_input_data
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -525,7 +525,7 @@ async fn store_receipt_data(
                     async_error,
                     &receipt_data_models
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -1,12 +1,11 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
 
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use diesel::pg::expression::array_comparison::any;
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::{ExpressionMethods, JoinOnDsl, PgConnection, QueryDsl};
 use futures::join;
 use num_traits::cast::FromPrimitive;
-use tokio_diesel::AsyncRunQueryDsl;
 use tracing::{error, warn};
 
 use crate::models;
@@ -14,7 +13,7 @@ use crate::schema;
 
 /// Saves receipts to database
 pub(crate) async fn store_receipts(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     receipts: &[near_indexer::near_primitives::views::ReceiptView],
     block_hash: &str,
     chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
@@ -80,7 +79,7 @@ pub(crate) async fn store_receipts(
 
 /// Looks for already created parent transaction hash for given receipts
 async fn find_tx_hashes_for_receipts(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     mut receipts: Vec<near_indexer::near_primitives::views::ReceiptView>,
     strict_mode: bool,
     block_hash: &str,
@@ -297,7 +296,7 @@ async fn find_tx_hashes_for_receipts(
 }
 
 async fn save_receipts(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     receipts: Vec<models::Receipt>,
 ) {
     let mut interval = crate::INTERVAL;
@@ -327,7 +326,7 @@ async fn save_receipts(
 }
 
 async fn store_receipt_actions(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     receipts: Vec<&near_indexer::near_primitives::views::ReceiptView>,
 ) {
     let receipt_actions: Vec<models::ActionReceipt> = receipts
@@ -500,7 +499,7 @@ async fn store_receipt_actions(
 }
 
 async fn store_receipt_data(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     receipts: Vec<&near_indexer::near_primitives::views::ReceiptView>,
 ) {
     let receipt_data_models: Vec<models::DataReceipt> = receipts

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -1,7 +1,6 @@
-use diesel::r2d2::{ConnectionManager, Pool};
+use actix_diesel::dsl::AsyncRunQueryDsl;
 use diesel::PgConnection;
 use futures::future::join_all;
-use tokio_diesel::AsyncRunQueryDsl;
 use tracing::error;
 
 use crate::models;
@@ -9,7 +8,7 @@ use crate::schema;
 
 /// Saves Transaction to database
 pub(crate) async fn store_transactions(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     chunks: &[near_indexer::IndexerChunkView],
     block_hash: &str,
     block_timestamp: u64,
@@ -34,7 +33,7 @@ pub(crate) async fn store_transactions(
 }
 
 async fn store_chunk_transactions(
-    pool: &Pool<ConnectionManager<PgConnection>>,
+    pool: &actix_diesel::Database<PgConnection>,
     transactions: Vec<&near_indexer::IndexerTransactionWithOutcome>,
     chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
     block_hash: &str,

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -71,7 +71,7 @@ async fn store_chunk_transactions(
                     async_error,
                     &transaction_models
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }
@@ -113,7 +113,7 @@ async fn store_chunk_transactions(
                     async_error,
                     &transaction_action_models,
                 );
-                tokio::time::delay_for(interval).await;
+                tokio::time::sleep(interval).await;
                 if interval < crate::MAX_DELAY_TIME {
                     interval *= 2;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -111,7 +111,7 @@ async fn listen_blocks(
 ) {
     let pool = std::sync::Arc::new(models::establish_connection());
     let strict_mode = allow_missing_relation_in_start_blocks.unwrap_or(0);
-    let mut handle_messages = stream
+    let mut handle_messages = tokio_stream::wrappers::ReceiverStream::new(stream)
         .enumerate()
         .map(|(index, streamer_message)| {
             info!(target: "indexer_for_explorer", "Block height {}", &streamer_message.block.header.height);

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,22 +171,23 @@ fn main() {
                     near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync
                 },
             };
-            let indexer = near_indexer::Indexer::new(indexer_config);
-            if args.store_genesis {
-                let near_config = indexer.near_config().clone();
-                actix::spawn(db_adapters::accounts::store_accounts_from_genesis(
-                    near_config.clone(),
+            actix::System::builder().stop_on_panic(true).run(move || {
+                let indexer = near_indexer::Indexer::new(indexer_config);
+                if args.store_genesis {
+                    let near_config = indexer.near_config().clone();
+                    actix::spawn(db_adapters::accounts::store_accounts_from_genesis(
+                        near_config.clone(),
+                    ));
+                    actix::spawn(db_adapters::access_keys::store_access_keys_from_genesis(
+                        near_config,
+                    ))
+                }
+                let stream = indexer.streamer();
+                actix::spawn(listen_blocks(
+                    stream,
+                    args.allow_missing_relations_in_first_blocks,
                 ));
-                actix::spawn(db_adapters::access_keys::store_access_keys_from_genesis(
-                    near_config,
-                ))
-            }
-            let stream = indexer.streamer();
-            actix::spawn(listen_blocks(
-                stream,
-                args.allow_missing_relations_in_first_blocks,
-            ));
-            indexer.start();
+            }).unwrap();
         }
         SubCommand::Init(config) => near_indexer::init_configs(
             &home_dir,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,6 @@ use std::convert::TryInto;
 use clap::Clap;
 #[macro_use]
 extern crate diesel;
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::PgConnection;
 use futures::{join, StreamExt};
 use tokio::sync::mpsc;
@@ -22,7 +21,7 @@ const INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_DELAY_TIME: std::time::Duration = std::time::Duration::from_secs(120);
 
 async fn handle_message(
-    pool: std::sync::Arc<Pool<ConnectionManager<PgConnection>>>,
+    pool: actix_diesel::Database<PgConnection>,
     streamer_message: near_indexer::StreamerMessage,
     strict_mode: bool,
 ) {
@@ -109,7 +108,7 @@ async fn listen_blocks(
     stream: mpsc::Receiver<near_indexer::StreamerMessage>,
     allow_missing_relation_in_start_blocks: Option<u32>,
 ) {
-    let pool = std::sync::Arc::new(models::establish_connection());
+    let pool = models::establish_connection();
     let strict_mode = allow_missing_relation_in_start_blocks.unwrap_or(0);
     let mut handle_messages = tokio_stream::wrappers::ReceiverStream::new(stream)
         .enumerate()
@@ -171,23 +170,26 @@ fn main() {
                     near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync
                 },
             };
-            actix::System::builder().stop_on_panic(true).run(move || {
-                let indexer = near_indexer::Indexer::new(indexer_config);
-                if args.store_genesis {
-                    let near_config = indexer.near_config().clone();
-                    actix::spawn(db_adapters::accounts::store_accounts_from_genesis(
-                        near_config.clone(),
+            actix::System::builder()
+                .stop_on_panic(true)
+                .run(move || {
+                    let indexer = near_indexer::Indexer::new(indexer_config);
+                    if args.store_genesis {
+                        let near_config = indexer.near_config().clone();
+                        actix::spawn(db_adapters::accounts::store_accounts_from_genesis(
+                            near_config.clone(),
+                        ));
+                        actix::spawn(db_adapters::access_keys::store_access_keys_from_genesis(
+                            near_config,
+                        ))
+                    }
+                    let stream = indexer.streamer();
+                    actix::spawn(listen_blocks(
+                        stream,
+                        args.allow_missing_relations_in_first_blocks,
                     ));
-                    actix::spawn(db_adapters::access_keys::store_access_keys_from_genesis(
-                        near_config,
-                    ))
-                }
-                let stream = indexer.streamer();
-                actix::spawn(listen_blocks(
-                    stream,
-                    args.allow_missing_relations_in_first_blocks,
-                ));
-            }).unwrap();
+                })
+                .unwrap();
         }
         SubCommand::Init(config) => near_indexer::init_configs(
             &home_dir,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,5 @@
 use std::env;
 
-use diesel::r2d2::{ConnectionManager, Pool};
 use diesel::PgConnection;
 use dotenv::dotenv;
 
@@ -29,13 +28,11 @@ pub mod receipts;
 mod serializers;
 pub mod transactions;
 
-pub(crate) fn establish_connection() -> Pool<ConnectionManager<PgConnection>> {
+pub(crate) fn establish_connection() -> actix_diesel::Database<PgConnection> {
     dotenv().ok();
 
     let database_url = env::var("DATABASE_URL")
         .unwrap_or_else(|_| panic!("DATABASE_URL must be set in .env file"));
-    let manager = ConnectionManager::<PgConnection>::new(&database_url);
-    Pool::builder()
-        .build(manager)
-        .unwrap_or_else(|_| panic!("Error connecting to {}", database_url))
+    actix_diesel::Database::builder()
+        .open(&database_url)
 }


### PR DESCRIPTION
Note: this is already compiled a few weeks ago, testnet is already using this version of NEAR Indexer for Explorer