### PR TITLE
fix: Fixed the type for accounts.id and account_changes.id to be auto-incrementing (bigserial)

### DIFF
--- a/migrations/2020-12-07-153402_initial_schema/up.sql
+++ b/migrations/2020-12-07-153402_initial_schema/up.sql
@@ -82,7 +82,7 @@ CREATE TABLE public.access_keys (
 --
 
 CREATE TABLE public.account_changes (
-    id bigint NOT NULL,
+    id bigserial NOT NULL,
     affected_account_id text NOT NULL,
     changed_in_block_timestamp numeric(20,0) NOT NULL,
     changed_in_block_hash text NOT NULL,
@@ -99,7 +99,7 @@ CREATE TABLE public.account_changes (
 --
 
 CREATE TABLE public.accounts (
-    id bigint NOT NULL,
+    id bigserial NOT NULL,
     account_id text NOT NULL,
     created_by_receipt_id text,
     deleted_by_receipt_id text,


### PR DESCRIPTION
Resolves https://github.com/near/near-indexer-for-explorer/issues/74#issuecomment-800721467

We failed to squash the 0.2.x migrations properly and did not stumble upon the issue before since we gradually upgraded the database instead of wiping it completely on our end.

There is no need for a new migration since with the original migration, nothing could be indexed properly anyway, so we just need to fix that initial migration.