### PR TITLE
fix(version): use the version from Cargo.toml instead of the hardcode…

### DIFF
--- a/src/configs.rs
+++ b/src/configs.rs
@@ -5,7 +5,15 @@ use clap::Clap;
 /// NEAR Indexer for Explorer
 /// Watches for stream of blocks from the chain
 #[derive(Clap, Debug)]
-#[clap(version = "0.1", author = "Near Inc. <hello@nearprotocol.com>")]
+#[clap(
+    version,
+    author,
+    about,
+    setting(clap::AppSettings::ColoredHelp),
+    setting(clap::AppSettings::DisableHelpSubcommand),
+    setting(clap::AppSettings::VersionlessSubcommands),
+    setting(clap::AppSettings::NextLineHelp)
+)]
 pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
     #[clap(short, long)]


### PR DESCRIPTION
…d one:

```
Before:
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/near-indexer-for-explorer (master)> ./target/debug/indexer-explorer --version
indexer-explorer 0.1

After:
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/near-indexer-for-explorer (master)> cargo build -p indexer-explorer
   Compiling indexer-explorer v0.6.1 (/home/sandi/workspace/near/near-indexer-for-explorer)
    Finished dev [unoptimized + debuginfo] target(s) in 30.33s
sandi@sandi-ThinkPad-X1-Carbon-7th ~/w/n/near-indexer-for-explorer (master)> ./target/debug/indexer-explorer --version
indexer-explorer 0.6.1
```