### PR TITLE
fix: Handle recreation of implicit accounts properly to avoid confusion for the users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.4
+
+* Fix the overwriting of `created_by_receipt_id` for implicit accounts that may confuse users ([see issue #68 for ref](https://github.com/near/near-indexer-for-explorer/issues/68))
+
 ## 0.6.3
 
 * Denormalize table `action_receipt_actions` in order to speed up some queries by avoid

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1906,7 +1906,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "actix",
  "actix-diesel",
@@ -2228,7 +2228,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "cached",
@@ -2255,7 +2255,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2271,7 +2271,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "chrono",
  "failure",
@@ -2285,7 +2285,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "borsh",
@@ -2307,7 +2307,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2345,7 +2345,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "chrono",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2387,7 +2387,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "cached",
@@ -2409,7 +2409,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.8.1"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "futures",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.1"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2459,7 +2459,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix-web",
  "futures",
@@ -2473,7 +2473,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "lazy_static",
@@ -2495,7 +2495,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "lazy_static",
  "log",
@@ -2505,7 +2505,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "borsh",
@@ -2539,7 +2539,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "bitflags",
@@ -2559,7 +2559,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "quote",
  "syn",
@@ -2568,7 +2568,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "near-crypto",
@@ -2579,7 +2579,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2610,7 +2610,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -2627,7 +2627,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2638,7 +2638,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -2651,7 +2651,7 @@ dependencies = [
 [[package]]
 name = "near-runtime-utils"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "lazy_static",
  "regex",
@@ -2676,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "byteorder",
@@ -2701,7 +2701,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "actix-web",
@@ -2717,7 +2717,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "hex",
@@ -2728,7 +2728,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -2746,7 +2746,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2772,8 +2772,8 @@ dependencies = [
 
 [[package]]
 name = "neard"
-version = "1.19.0-rc.2"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+version = "1.19.0"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2829,7 +2829,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=daf13ddfa7341883f4c8eb00b063a98757dc59c8#daf13ddfa7341883f4c8eb00b063a98757dc59c8"
+source = "git+https://github.com/near/nearcore?rev=9a7d172adeefcfd522723d741c2fa2d134392b8f#9a7d172adeefcfd522723d741c2fa2d134392b8f"
 dependencies = [
  "borsh",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 
@@ -31,5 +31,5 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 
 actix-diesel = { git = "https://github.com/frol/actix-diesel", branch="actix-0.11-beta.2" }
-near-indexer = { git = "https://github.com/near/nearcore", rev="daf13ddfa7341883f4c8eb00b063a98757dc59c8" }
-near-crypto = { git = "https://github.com/near/nearcore", rev="daf13ddfa7341883f4c8eb00b063a98757dc59c8" }
+near-indexer = { git = "https://github.com/near/nearcore", rev="9a7d172adeefcfd522723d741c2fa2d134392b8f" }
+near-crypto = { git = "https://github.com/near/nearcore", rev="9a7d172adeefcfd522723d741c2fa2d134392b8f" }


### PR DESCRIPTION
Fixes #68 

Also I've changed `nearcore` dependency hash to the release hash of [1.19.0](https://github.com/near/nearcore/releases/tag/1.19.0) Only a version has changed in that commit in compare with previous, but I decided to stick to the release as it is perfect timing for that.

I've tried to leave comments and renamed some variables as I've found them a bit misleading.