### PR TITLE
fix: unique indexes in account_changes table should contain update_reason

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.7
+
+* Remove duplicates from `account_changes` table by fixing unique index ([see issue #74](https://github.com/near/near-indexer-for-explorer/issues/74))
+
 ## 0.6.6 (hotfix)
 
 * Upgrade `nearcore` to 1.19.1 (hotfix)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,7 +1917,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.6.6"
+version = "0.6.7"
 dependencies = [
  "actix",
  "actix-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.6.6"
+version = "0.6.7"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/migrations/2021-05-27-154211_account_changes_unique_idx/down.sql
+++ b/migrations/2021-05-27-154211_account_changes_unique_idx/down.sql
@@ -1,3 +1,12 @@
+-- See comment in corresponding up.sql
+-- We decided to add it anyway for consistency
+ALTER TABLE ONLY account_changes
+    ADD CONSTRAINT account_changes_affected_account_id_changed_in_block_hash_c_key UNIQUE (
+    affected_account_id,
+    changed_in_block_hash,
+    caused_by_transaction_hash,
+    caused_by_receipt_id);
+
 DROP INDEX IF EXISTS account_changes_transaction_uni_idx;
 DROP INDEX IF EXISTS account_changes_receipt_uni_idx;
 DROP INDEX IF EXISTS account_changes_null_uni_idx;

--- a/migrations/2021-05-27-154211_account_changes_unique_idx/up.sql
+++ b/migrations/2021-05-27-154211_account_changes_unique_idx/up.sql
@@ -1,11 +1,11 @@
 CREATE UNIQUE INDEX account_changes_transaction_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash, caused_by_transaction_hash)
+ON account_changes (affected_account_id, changed_in_block_hash, caused_by_transaction_hash, update_reason)
 WHERE caused_by_transaction_hash IS NOT NULL AND caused_by_receipt_id IS NULL;
 
 CREATE UNIQUE INDEX account_changes_receipt_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash, caused_by_receipt_id)
+ON account_changes (affected_account_id, changed_in_block_hash, caused_by_receipt_id, update_reason)
 WHERE caused_by_transaction_hash IS NULL AND caused_by_receipt_id IS NOT NULL;
 
 CREATE UNIQUE INDEX account_changes_null_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash)
+ON account_changes (affected_account_id, changed_in_block_hash, update_reason)
 WHERE caused_by_transaction_hash IS NULL AND caused_by_receipt_id IS NULL;

--- a/migrations/2021-05-27-154211_account_changes_unique_idx/up.sql
+++ b/migrations/2021-05-27-154211_account_changes_unique_idx/up.sql
@@ -1,11 +1,40 @@
+-- This constraint is bad because of 2 reasons:
+-- 1. It does not contain update_reason, so it can remove needed lines
+-- 2. Fortunately, it does not work at all because we have 2 nullable columns, they could not be compared by equality
+--    (all nulls are considered unique)
+ALTER TABLE account_changes DROP CONSTRAINT IF EXISTS account_changes_affected_account_id_changed_in_block_hash_c_key;
+
 CREATE UNIQUE INDEX account_changes_transaction_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash, caused_by_transaction_hash, update_reason)
+ON account_changes (
+    affected_account_id,
+    changed_in_block_hash,
+    caused_by_transaction_hash,
+    update_reason,
+    affected_account_nonstaked_balance,
+    affected_account_staked_balance,
+    affected_account_storage_usage
+)
 WHERE caused_by_transaction_hash IS NOT NULL AND caused_by_receipt_id IS NULL;
 
 CREATE UNIQUE INDEX account_changes_receipt_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash, caused_by_receipt_id, update_reason)
+ON account_changes (
+    affected_account_id,
+    changed_in_block_hash,
+    caused_by_receipt_id,
+    update_reason,
+    affected_account_nonstaked_balance,
+    affected_account_staked_balance,
+    affected_account_storage_usage
+)
 WHERE caused_by_transaction_hash IS NULL AND caused_by_receipt_id IS NOT NULL;
 
 CREATE UNIQUE INDEX account_changes_null_uni_idx
-ON account_changes (affected_account_id, changed_in_block_hash, update_reason)
+ON account_changes (
+    affected_account_id,
+    changed_in_block_hash,
+    update_reason,
+    affected_account_nonstaked_balance,
+    affected_account_staked_balance,
+    affected_account_storage_usage
+)
 WHERE caused_by_transaction_hash IS NULL AND caused_by_receipt_id IS NULL;


### PR DESCRIPTION
See an example:
```
select * from account_changes 
where account_changes.affected_account_id = '0520974a09c1e419a208b9238363df42df30ff94.lockup.near' 
and account_changes.changed_in_block_timestamp = 1604431876987521027 
and account_changes.caused_by_receipt_id = 'HUEGvT8ceLGWgGyx2o8vsSgoRnSEkpgJsi4UbeiaMsXJ'
order by account_changes.changed_in_block_timestamp desc, id desc;
```

In the result, all the columns are the same except `update_reason`: it's `ACTION_RECEIPT_GAS_REWARD` and `RECEIPT_PROCESSING`, in the same block and receipt
So we should put `update_reason` to index also.

This one is also not OK for the same reason, and I'm not sure what should we do with it. Honestly, we could just delete it, it does nothing. Is it OK to remove this line in this PR also?
https://github.com/near/near-indexer-for-explorer/blob/master/migrations/2020-12-07-153402_initial_schema/up.sql#L285
