### PR TITLE
feat: speed up sorting in transactions

### DIFF
--- a/migrations/2021-08-02-183200_transactions_sorting_idx/down.sql
+++ b/migrations/2021-08-02-183200_transactions_sorting_idx/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX transactions_sorting_idx;

--- a/migrations/2021-08-02-183200_transactions_sorting_idx/up.sql
+++ b/migrations/2021-08-02-183200_transactions_sorting_idx/up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX CONCURRENTLY transactions_sorting_idx ON transactions (block_timestamp, index_in_chunk);


### PR DESCRIPTION
Resolves #135 

To apply it to mainnet, we should use 
```sql
CREATE INDEX CONCURRENTLY transactions_sorting_idx ON transactions(block_timestamp, index_in_chunk);
```

(We never put `CONCURRENTLY` to migration files, I decided that I should be consistent here)

Applying it to `35.233.39.106` (it's copy of mainnet with data till 10th of May 2021) took 75 seconds.
Select from @frol works in a moment.
Important: columns `block_timestamp, index_in_chunk`should always go in this order, and we should specify `desc` for both or for no columns. That anyway sounds logical.

```sql
select pg_size_pretty(pg_table_size('transactions_sorting_idx'));
```
For 14M lines, it took 550 MB of storage. Mainnet has 17M lines, so hopefully it should not be so far from these numbers.

Can I apply it to mainnet?