### PR TITLE
fix: remove CONCURRENTLY from migration

### DIFF
--- a/migrations/2021-08-02-183200_transactions_sorting_idx/up.sql
+++ b/migrations/2021-08-02-183200_transactions_sorting_idx/up.sql
@@ -1,1 +1,1 @@
-CREATE INDEX CONCURRENTLY transactions_sorting_idx ON transactions (block_timestamp, index_in_chunk);
+CREATE INDEX transactions_sorting_idx ON transactions (block_timestamp, index_in_chunk);


### PR DESCRIPTION
CREATE INDEX CONCURRENTLY cannot run inside a transaction block