### PR TITLE
feat: introduced an easy way to sort account_changes in their correct historical order (changed_in_block_timestamp + index_in_block)

### DIFF
--- a/migrations/2021-08-06-123500_account_changes_ordering_column/down.sql
+++ b/migrations/2021-08-06-123500_account_changes_ordering_column/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account_changes DROP COLUMN index_in_block;

--- a/migrations/2021-08-06-123500_account_changes_ordering_column/up.sql
+++ b/migrations/2021-08-06-123500_account_changes_ordering_column/up.sql
@@ -1,0 +1,62 @@
+-- Setting default value -1 for further fill with data to avoid making the field nullable
+ALTER TABLE account_changes
+    ADD COLUMN index_in_block integer NOT NULL DEFAULT -1;
+
+-- This migration is heavy to apply. Consider using Python script to do that in background.
+-- It applies the changes by tiny pieces.
+-- You need to replace `END` and `connection_string` parameters
+
+-- from sqlalchemy import create_engine
+--
+--     START = 1595370903490523743
+--     STEP = 1000 * 1000 * 1000 * 1000  # 1000 secs -> ~17 minutes
+-- END = 1628683241000000000
+-- ESTIMATED_STEPS = (END - START) / STEP
+-- connection_string = 'postgresql+psycopg2://user:pass@host/database'
+--
+--
+-- def generate_sql(from_timestamp: int, to_timestamp: int) -> str:
+--     """
+--     Generates str for SQL query to convert args_base64 to args_json if possible
+--     """
+--     return f"""
+--     WITH indexes AS
+--          (
+--              SELECT id, row_number() OVER (PARTITION BY changed_in_block_timestamp ORDER BY id) - 1 as index_in_block
+--              FROM account_changes
+--              WHERE account_changes.changed_in_block_timestamp >= {from_timestamp}
+--                 AND account_changes.changed_in_block_timestamp <= {to_timestamp}
+--          )
+--     UPDATE account_changes
+--     SET index_in_block = indexes.index_in_block
+--     FROM indexes
+--     WHERE account_changes.id = indexes.id
+--         AND account_changes.index_in_block = -1
+--         AND account_changes.changed_in_block_timestamp >= {from_timestamp}
+--         AND account_changes.changed_in_block_timestamp <= {to_timestamp};
+--     """
+--
+--
+-- if __name__ == '__main__':
+--     print("Establishing connection to %s..." % (connection_string.split('/')[-1],))
+--     engine = create_engine(connection_string)
+--     print(f"Estimated queries to execute: {ESTIMATED_STEPS}.")
+--     from_timestamp = START-STEP
+--     to_timestamp = START
+-- counter = 1
+-- with engine.connect() as con:
+--     while True:
+--     from_timestamp += STEP
+--     to_timestamp += STEP
+--     if (END - to_timestamp) < STEP:
+--     break
+--     print(f"{counter}/{ESTIMATED_STEPS} (from {from_timestamp} to {to_timestamp})")
+--
+--     out = con.execute(generate_sql(from_timestamp, to_timestamp))
+--     print(out.rowcount)
+--     counter += 1
+--
+--     print("FINISHED")
+
+ALTER TABLE account_changes
+    ALTER COLUMN index_in_block DROP DEFAULT;

--- a/src/db_adapters/account_changes.rs
+++ b/src/db_adapters/account_changes.rs
@@ -18,11 +18,13 @@ pub(crate) async fn store_account_changes(
 
     let account_changes_models: Vec<models::account_changes::AccountChange> = state_changes
         .iter()
-        .filter_map(|state_change| {
+        .enumerate()
+        .filter_map(|(index_in_block, state_change)| {
             models::account_changes::AccountChange::from_state_change_with_cause(
                 state_change,
                 &block_hash,
                 block_timestamp,
+                index_in_block as i32,
             )
         })
         .collect();

--- a/src/models/account_changes.rs
+++ b/src/models/account_changes.rs
@@ -17,6 +17,7 @@ pub struct AccountChange {
     pub affected_account_nonstaked_balance: BigDecimal,
     pub affected_account_staked_balance: BigDecimal,
     pub affected_account_storage_usage: BigDecimal,
+    pub index_in_block: i32,
 }
 
 impl AccountChange {
@@ -24,6 +25,7 @@ impl AccountChange {
         state_change_with_cause: &near_indexer::near_primitives::views::StateChangeWithCauseView,
         changed_in_block_hash: &near_indexer::near_primitives::hash::CryptoHash,
         changed_in_block_timestamp: u64,
+        index_in_block: i32,
     ) -> Option<Self> {
         let near_indexer::near_primitives::views::StateChangeWithCauseView { cause, value } =
             state_change_with_cause;
@@ -75,7 +77,8 @@ impl AccountChange {
                 acc.storage_usage.into()
             } else {
                 BigDecimal::from(0)
-            }
+            },
+            index_in_block
         })
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -27,6 +27,7 @@ table! {
         affected_account_nonstaked_balance -> Numeric,
         affected_account_staked_balance -> Numeric,
         affected_account_storage_usage -> Numeric,
+        index_in_block -> Int4,
     }
 }
 


### PR DESCRIPTION
*Partially resolves #77* (this PR introduces an easy way to sort the account changing events: `ORDER BY changed_in_block_timestamp, index_in_block`)

I am still waiting for the server updates, want to test it on the production-like env, that's why I marked it as a draft.

We should apply the migration by pieces, otherwise, it will take too long to update existing lines.