### PR TITLE
feat: add ft, nft aggregated tables

### DIFF
--- a/migrations/2021-08-23-161500_aggregated_ft_nft_tables/down.sql
+++ b/migrations/2021-08-23-161500_aggregated_ft_nft_tables/down.sql
@@ -1,0 +1,2 @@
+DROP TABLE aggregated__fungible_tokens;
+DROP TABLE aggregated__non_fungible_tokens;

--- a/migrations/2021-08-23-161500_aggregated_ft_nft_tables/up.sql
+++ b/migrations/2021-08-23-161500_aggregated_ft_nft_tables/up.sql
@@ -1,62 +1,64 @@
-CREATE TABLE aggregated__fungible_tokens
+CREATE TABLE aggregated__fungible_token_operations
 (
-    id                                bigserial                NOT NULL,
-    included_in_transaction_hash      text                     NOT NULL,
-    included_in_transaction_timestamp numeric(20, 0)           NOT NULL,
-    transaction_status                execution_outcome_status NOT NULL,
-    issued_contract_id                text                     NOT NULL,
-    called_method                     text                     NOT NULL,
-    predecessor_account_id            text                     NOT NULL,
-    receiver_account_id               text                     NOT NULL,
-    amount                            numeric(45, 0)           NOT NULL,
-    args                              jsonb                    NOT NULL
+    processed_in_block_timestamp  numeric(20, 0) NOT NULL,
+    processed_in_transaction_hash text           NOT NULL,
+    processing_index_in_chunk     integer        NOT NULL,
+    ft_contract_account_id        text           NOT NULL,
+    ft_affected_account_id        text           NOT NULL,
+    called_method                 text           NOT NULL,
+    ft_affected_account_balance   numeric(45, 0) NOT NULL,
+    args                          jsonb          NOT NULL
 );
 
-ALTER TABLE ONLY aggregated__fungible_tokens
-    ADD CONSTRAINT aggregated__fungible_tokens_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY aggregated__fungible_token_operations
+    ADD CONSTRAINT aggregated__fungible_token_operations_pkey PRIMARY KEY (processed_in_transaction_hash,
+                                                                           ft_contract_account_id,
+                                                                           ft_affected_account_id);
 
-CREATE INDEX aggregated__fungible_tokens_timestamp_idx ON aggregated__fungible_tokens USING btree (included_in_transaction_timestamp);
+-- I will edit it after we finalise the naming
+-- CREATE INDEX aggregated__fungible_tokens_timestamp_idx ON aggregated__fungible_tokens USING btree (included_in_transaction_timestamp);
+--
+-- ALTER TABLE ONLY aggregated__fungible_tokens
+--     ADD CONSTRAINT aggregated__fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__fungible_tokens
+--     ADD CONSTRAINT aggregated__ft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__fungible_tokens
+--     ADD CONSTRAINT aggregated__ft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__fungible_tokens
+--     ADD CONSTRAINT aggregated__ft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
 
-ALTER TABLE ONLY aggregated__fungible_tokens
-    ADD CONSTRAINT aggregated__fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__fungible_tokens
-    ADD CONSTRAINT aggregated__ft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__fungible_tokens
-    ADD CONSTRAINT aggregated__ft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__fungible_tokens
-    ADD CONSTRAINT aggregated__ft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
-
-CREATE TABLE aggregated__non_fungible_tokens
+CREATE TABLE aggregated__non_fungible_token_operations
 (
-    id                                bigserial                NOT NULL,
-    included_in_transaction_hash      text                     NOT NULL,
-    included_in_transaction_timestamp numeric(20, 0)           NOT NULL,
-    transaction_status                execution_outcome_status NOT NULL,
-    issued_contract_id                text                     NOT NULL,
-    called_method                     text                     NOT NULL,
-    non_fungible_token_id             text                     NOT NULL,
-    predecessor_account_id            text                     NOT NULL,
-    receiver_account_id               text                     NOT NULL,
-    amount                            numeric(45, 0)           NOT NULL,
-    args                              jsonb                    NOT NULL
+    processed_in_block_timestamp  numeric(20, 0) NOT NULL,
+    processed_in_transaction_hash text           NOT NULL,
+    processing_index_in_chunk     integer        NOT NULL,
+    nft_contract_account_id       text           NOT NULL,
+    nft_affected_account_id       text           NOT NULL,
+    called_method                 text           NOT NULL,
+    nft_id                        text           NOT NULL,
+    args                          jsonb          NOT NULL
 );
 
-ALTER TABLE ONLY aggregated__non_fungible_tokens
-    ADD CONSTRAINT aggregated__non_fungible_tokens_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY aggregated__non_fungible_token_operations
+    ADD CONSTRAINT aggregated__non_fungible_token_operations_pkey PRIMARY KEY (processed_in_transaction_hash,
+                                                                               nft_contract_account_id,
+                                                                               nft_affected_account_id,
+                                                                               nft_id);
 
-CREATE INDEX aggregated__non_fungible_tokens_timestamp_idx ON aggregated__non_fungible_tokens USING btree (included_in_transaction_timestamp);
-
-ALTER TABLE ONLY aggregated__non_fungible_tokens
-    ADD CONSTRAINT aggregated__non_fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__non_fungible_tokens
-    ADD CONSTRAINT aggregated__nft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__non_fungible_tokens
-    ADD CONSTRAINT aggregated__nft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
-
-ALTER TABLE ONLY aggregated__non_fungible_tokens
-    ADD CONSTRAINT aggregated__nft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+-- I will edit it after we finalise the naming
+-- CREATE INDEX aggregated__non_fungible_tokens_timestamp_idx ON aggregated__non_fungible_tokens USING btree (included_in_transaction_timestamp);
+--
+-- ALTER TABLE ONLY aggregated__non_fungible_tokens
+--     ADD CONSTRAINT aggregated__non_fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__non_fungible_tokens
+--     ADD CONSTRAINT aggregated__nft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__non_fungible_tokens
+--     ADD CONSTRAINT aggregated__nft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+--
+-- ALTER TABLE ONLY aggregated__non_fungible_tokens
+--     ADD CONSTRAINT aggregated__nft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;

--- a/migrations/2021-08-23-161500_aggregated_ft_nft_tables/up.sql
+++ b/migrations/2021-08-23-161500_aggregated_ft_nft_tables/up.sql
@@ -1,0 +1,62 @@
+CREATE TABLE aggregated__fungible_tokens
+(
+    id                                bigserial                NOT NULL,
+    included_in_transaction_hash      text                     NOT NULL,
+    included_in_transaction_timestamp numeric(20, 0)           NOT NULL,
+    transaction_status                execution_outcome_status NOT NULL,
+    issued_contract_id                text                     NOT NULL,
+    called_method                     text                     NOT NULL,
+    predecessor_account_id            text                     NOT NULL,
+    receiver_account_id               text                     NOT NULL,
+    amount                            numeric(45, 0)           NOT NULL,
+    args                              jsonb                    NOT NULL
+);
+
+ALTER TABLE ONLY aggregated__fungible_tokens
+    ADD CONSTRAINT aggregated__fungible_tokens_pkey PRIMARY KEY (id);
+
+CREATE INDEX aggregated__fungible_tokens_timestamp_idx ON aggregated__fungible_tokens USING btree (included_in_transaction_timestamp);
+
+ALTER TABLE ONLY aggregated__fungible_tokens
+    ADD CONSTRAINT aggregated__fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__fungible_tokens
+    ADD CONSTRAINT aggregated__ft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__fungible_tokens
+    ADD CONSTRAINT aggregated__ft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__fungible_tokens
+    ADD CONSTRAINT aggregated__ft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+
+CREATE TABLE aggregated__non_fungible_tokens
+(
+    id                                bigserial                NOT NULL,
+    included_in_transaction_hash      text                     NOT NULL,
+    included_in_transaction_timestamp numeric(20, 0)           NOT NULL,
+    transaction_status                execution_outcome_status NOT NULL,
+    issued_contract_id                text                     NOT NULL,
+    called_method                     text                     NOT NULL,
+    non_fungible_token_id             text                     NOT NULL,
+    predecessor_account_id            text                     NOT NULL,
+    receiver_account_id               text                     NOT NULL,
+    amount                            numeric(45, 0)           NOT NULL,
+    args                              jsonb                    NOT NULL
+);
+
+ALTER TABLE ONLY aggregated__non_fungible_tokens
+    ADD CONSTRAINT aggregated__non_fungible_tokens_pkey PRIMARY KEY (id);
+
+CREATE INDEX aggregated__non_fungible_tokens_timestamp_idx ON aggregated__non_fungible_tokens USING btree (included_in_transaction_timestamp);
+
+ALTER TABLE ONLY aggregated__non_fungible_tokens
+    ADD CONSTRAINT aggregated__non_fungible_tokens_fk FOREIGN KEY (included_in_transaction_hash) REFERENCES transactions (transaction_hash) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__non_fungible_tokens
+    ADD CONSTRAINT aggregated__nft_issued_contract_id_fk FOREIGN KEY (issued_contract_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__non_fungible_tokens
+    ADD CONSTRAINT aggregated__nft_predecessor_account_id_fk FOREIGN KEY (predecessor_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY aggregated__non_fungible_tokens
+    ADD CONSTRAINT aggregated__nft_receiver_account_id_fk FOREIGN KEY (receiver_account_id) REFERENCES accounts (account_id) ON DELETE CASCADE;


### PR DESCRIPTION
Please have a look at the columns in both tables.
[FT](https://github.com/near/near-indexer-for-explorer/pull/153/files#diff-dbc27ed818d6f8bbaca70b3e91417c908a5815bfd961e460b75f672955ec70d1R1-R13)
[NFT](https://github.com/near/near-indexer-for-explorer/pull/153/files#diff-dbc27ed818d6f8bbaca70b3e91417c908a5815bfd961e460b75f672955ec70d1R32-R45)


### FT

https://github.com/near/NEPs/issues/141

We can also add nullable `memo` field. Though, I thought it's not so important and we can store it in `args`. I also have a plan to put there all the other data that we have.

### NFT

https://github.com/near/NEPs/discussions/171

Same things about `memo` and `args`.

We also can add nullable `approval_id` field, read more about it here:
https://github.com/near/NEPs/blob/master/specs/Standards/NonFungibleToken/ApprovalManagement.md

Any feedback is highly appreciated!

I guess I can implement the first draft and check what we put into `args`. After that, we can finalize the columns.