### PR TITLE
refactor: Strict/Non-strict mode improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Drop `--allow-missing-relations-in-first-blocks` flag
 * Introduce `--non-strict-mode` which does the same as `--allow-missing-relations-in-first-blocks` flag did but endlessly
-* Add `--stop-after-number-of-blocks <amount>` flag to plan Indexer for Explorer to stop once it indexed the provided `<amount>` of blocks. May be useful for debug or maintenance purposes.
+* Add `--stop-after-number-of-blocks <count>` flag to plan Indexer for Explorer to stop once it indexed the provided `<count>` of blocks. May be useful for debug or maintenance purposes.
 
 ## Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 0.10.0
+
+* Drop `--allow-missing-relations-in-first-blocks` flag
+* Introduce `--non-strict-mode` which does the same as `--allow-missing-relations-in-first-blocks` flag did but endlessly
+* Add `--stop-after-number-of-blocks <amount>` flag to plan Indexer for Explorer to stop once it indexed the provided `<amount>` of blocks. May be useful for debug or maintenance purposes.
+
+## Breaking changes
+
+* The flag `--allow-missing-relations-in-first-blocks` is not available anymore in favor of `--non-strict-mode` flag
+
 ## 0.9.3
 
 * Escape `args_json` on the fly to avoid null-byte issues

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1990,7 +1990,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "actix",
  "actix-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -38,12 +38,12 @@ pub(crate) struct RunArgs {
     /// Force streaming while node is syncing
     #[clap(long)]
     pub stream_while_syncing: bool,
-    /// Switches indexer to non-strict mode (skips Receipts without parent Transaction hash, stops storing AccountChanges)
+    /// Switches indexer to non-strict mode (skips Receipts without parent Transaction hash, stops storing AccountChanges and AccessKeys)
     #[clap(long)]
     pub non_strict_mode: bool,
     /// Stops indexer completely after indexing the provided number of blocks
     #[clap(long, short)]
-    pub stop_after_number_of_blocks: Option<u64>,
+    pub stop_after_number_of_blocks: Option<std::num::NonZeroUsize>,
     /// Sets the concurrency for indexing. Note: concurrency (set to 2+) may lead to warnings due to tight constraints between transactions and receipts (those will get resolved eventually, but unless it is the second pass of indexing, concurrency won't help at the moment).
     #[clap(long, default_value = "1")]
     pub concurrency: std::num::NonZeroU16,

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -38,12 +38,17 @@ pub(crate) struct RunArgs {
     /// Force streaming while node is syncing
     #[clap(long)]
     pub stream_while_syncing: bool,
+    /// Switches indexer to non-strict mode (skips Receipts without parent Transaction hash, stops storing AccountChanges)
     #[clap(long)]
-    pub allow_missing_relations_in_first_blocks: Option<u32>,
-    #[clap(subcommand)]
-    pub sync_mode: SyncModeSubCommand,
+    pub non_strict_mode: bool,
+    /// Stops indexer completely after indexing the provided amount of blocks
+    #[clap(long, short)]
+    pub stop_after_number_of_blocks: Option<u64>,
+    /// Sets the concurrency for indexing. Note: high concurrency level may lead to race conditions
     #[clap(long, default_value = "1")]
     pub concurrency: std::num::NonZeroU16,
+    #[clap(subcommand)]
+    pub sync_mode: SyncModeSubCommand,
 }
 
 #[allow(clippy::enum_variant_names)] // we want commands to be more explicit
@@ -59,7 +64,7 @@ pub(crate) enum SyncModeSubCommand {
 
 #[derive(Clap, Debug, Clone)]
 pub(crate) struct InterruptionArgs {
-    /// start sycing this amount of blocks earlier than actual interruption
+    /// start syncing this amount of blocks earlier than actual interruption
     #[clap(long, default_value = "0")]
     pub delta: u64,
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -44,7 +44,7 @@ pub(crate) struct RunArgs {
     /// Stops indexer completely after indexing the provided amount of blocks
     #[clap(long, short)]
     pub stop_after_number_of_blocks: Option<u64>,
-    /// Sets the concurrency for indexing. Note: high concurrency level may lead to race conditions
+    /// Sets the concurrency for indexing. Note: concurrency (set to 2+) may lead to warnings due to tight constraints between transactions and receipts (those will get resolved eventually, but unless it is the second pass of indexing, concurrency won't help at the moment).
     #[clap(long, default_value = "1")]
     pub concurrency: std::num::NonZeroU16,
     #[clap(subcommand)]
@@ -64,7 +64,7 @@ pub(crate) enum SyncModeSubCommand {
 
 #[derive(Clap, Debug, Clone)]
 pub(crate) struct InterruptionArgs {
-    /// start syncing this amount of blocks earlier than actual interruption
+    /// start indexing this number of blocks earlier than the actual interruption happened
     #[clap(long, default_value = "0")]
     pub delta: u64,
 }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -41,7 +41,7 @@ pub(crate) struct RunArgs {
     /// Switches indexer to non-strict mode (skips Receipts without parent Transaction hash, stops storing AccountChanges)
     #[clap(long)]
     pub non_strict_mode: bool,
-    /// Stops indexer completely after indexing the provided amount of blocks
+    /// Stops indexer completely after indexing the provided number of blocks
     #[clap(long, short)]
     pub stop_after_number_of_blocks: Option<u64>,
     /// Sets the concurrency for indexing. Note: concurrency (set to 2+) may lead to warnings due to tight constraints between transactions and receipts (those will get resolved eventually, but unless it is the second pass of indexing, concurrency won't help at the moment).

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -96,7 +96,7 @@ async fn find_tx_hashes_for_receipts(
 ) -> HashMap<String, String> {
     let mut tx_hashes_for_receipts: HashMap<String, String> = HashMap::new();
 
-    let mut retries_left: u8 = 10; // retry at least times even in no-strict mode to avoid data loss
+    let mut retries_left: u8 = 4; // retry at least times even in no-strict mode to avoid data loss
     let mut find_tx_retry_interval = crate::INTERVAL;
     loop {
         let data_ids: Vec<String> = receipts

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use std::convert::{TryFrom, TryInto};
 use clap::Clap;
+use std::convert::{TryFrom, TryInto};
 #[macro_use]
 extern crate diesel;
 
@@ -127,8 +127,8 @@ async fn listen_blocks(
     stop_after_number_of_blocks: Option<u64>,
 ) {
     tracing::info!(target: crate::INDEXER_FOR_EXPLORER, "Stream has started");
-    let handle_messages = tokio_stream::wrappers::ReceiverStream::new(stream)
-        .map(|streamer_message| {
+    let handle_messages =
+        tokio_stream::wrappers::ReceiverStream::new(stream).map(|streamer_message| {
             info!(
                 target: crate::INDEXER_FOR_EXPLORER,
                 "Block height {}", &streamer_message.block.header.height
@@ -136,7 +136,9 @@ async fn listen_blocks(
             handle_message(&pool, streamer_message, strict_mode)
         });
     let mut handle_messages = if let Some(stop_after_n_blocks) = stop_after_number_of_blocks {
-        handle_messages.take(stop_after_n_blocks as usize).boxed_local()
+        handle_messages
+            .take(stop_after_n_blocks as usize)
+            .boxed_local()
     } else {
         handle_messages.boxed_local()
     }
@@ -293,7 +295,8 @@ fn main() {
                     args.concurrency,
                     !args.non_strict_mode,
                     args.stop_after_number_of_blocks,
-                ).await;
+                )
+                .await;
 
                 actix::System::current().stop();
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -145,11 +145,7 @@ async fn listen_blocks(
         });
     let mut handle_messages = if let Some(stop_after_n_blocks) = stop_after_number_of_blocks {
         handle_messages
-            .take(
-                stop_after_n_blocks
-                    .try_into()
-                    .expect("NonZeroUsize is expected to be converted into `usize`"),
-            )
+            .take(stop_after_n_blocks.get())
             .boxed_local()
     } else {
         handle_messages.boxed_local()


### PR DESCRIPTION
Fixes #163 

I've bumped the version to `0.10.0` because I've dropped the `--allow-missing-relations-in-first-blocks` flag completely. It **doesn't mean** this PR is going to be released once merged.

* Dropped `--allow-missing-relations-in-first-blocks` flag completely
* Add the flag `--non-strict-mode` which: 
  * changes retry attempts on Receipts from 10 to 4
  * stops saving `account_changes` completely as it is impossible to save in case of missing of related Receipts
* Add the flag `--stop-after-number-of-blocks N` which namely stops the indexer after processing N blocks

All those flags and features are useful for debugging or emergency purposes. They are not supposed to be used in normal circumstances.