### PR TITLE
fix(nearcore) Upgrade nearcore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.1
+
+* Upgrade `nearcore` to 1.21.1
+
 ## 0.10.0
 
 * Drop `--allow-missing-relations-in-first-blocks` flag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2028,7 +2028,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "actix",
  "actix-diesel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -589,7 +589,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 dependencies = [
- "block-padding 0.1.5",
+ "block-padding",
  "byte-tools",
  "byteorder",
  "generic-array 0.12.4",
@@ -601,7 +601,6 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
  "generic-array 0.14.4",
 ]
 
@@ -613,12 +612,6 @@ checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
  "byte-tools",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "borsh"
@@ -1576,6 +1569,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
+dependencies = [
+ "ethbloom",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types",
+ "uint 0.9.1",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1978,6 +1998,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "impl-rlp"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+dependencies = [
+ "rlp",
+]
+
+[[package]]
+name = "impl-serde"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2354,7 +2392,7 @@ checksum = "0debeb9fcf88823ea64d64e4a815ab1643f33127d995978e099942ce38f25238"
 [[package]]
 name = "near-account-id"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "serde",
@@ -2363,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "cached",
@@ -2381,7 +2419,6 @@ dependencies = [
  "near-store",
  "num-rational 0.3.2",
  "rand 0.7.3",
- "rayon",
  "serde",
  "strum",
  "thiserror",
@@ -2391,7 +2428,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2407,7 +2444,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "chrono",
  "failure",
@@ -2421,7 +2458,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "borsh 0.8.2",
@@ -2430,7 +2467,6 @@ dependencies = [
  "futures",
  "log",
  "near-chain",
- "near-chunks-primitives",
  "near-crypto",
  "near-network",
  "near-pool",
@@ -2442,17 +2478,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-chunks-primitives"
-version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
-dependencies = [
- "near-chain-primitives",
-]
-
-[[package]]
 name = "near-client"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2478,6 +2506,7 @@ dependencies = [
  "near-store",
  "near-telemetry",
  "near-vm-runner",
+ "node-runtime",
  "num-rational 0.3.2",
  "rand 0.7.3",
  "reed-solomon-erasure",
@@ -2491,15 +2520,15 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "chrono",
  "near-chain-configs",
  "near-chain-primitives",
- "near-chunks-primitives",
+ "near-chunks",
  "near-crypto",
- "near-network-primitives",
+ "near-network",
  "near-primitives",
  "serde",
  "strum",
@@ -2509,7 +2538,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2519,11 +2548,11 @@ dependencies = [
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
+ "ethereum-types",
  "lazy_static",
  "libc",
  "near-account-id",
  "parity-secp256k1",
- "primitive-types",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -2535,7 +2564,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.1"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "cached",
@@ -2556,8 +2585,8 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "0.10.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+version = "0.9.2"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "async-recursion",
@@ -2578,7 +2607,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.2.2"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2598,7 +2627,7 @@ dependencies = [
  "near-network",
  "near-performance-metrics",
  "near-primitives",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f)",
  "prometheus",
  "serde",
  "serde_json",
@@ -2610,7 +2639,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -2626,7 +2655,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.2.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "lazy_static",
@@ -2636,7 +2665,7 @@ dependencies = [
  "near-metrics",
  "near-primitives",
  "near-primitives-core",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f)",
  "serde",
  "serde_json",
  "thiserror",
@@ -2647,7 +2676,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "lazy_static",
  "log",
@@ -2657,7 +2686,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "borsh 0.8.2",
@@ -2669,16 +2698,18 @@ dependencies = [
  "conqueue",
  "futures",
  "lazy_static",
+ "near-chain",
  "near-chain-configs",
  "near-crypto",
  "near-metrics",
- "near-network-primitives",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-primitives",
  "near-rust-allocator-proxy",
  "near-store",
  "rand 0.7.3",
+ "serde",
+ "serde_json",
  "strum",
  "tokio",
  "tokio-stream",
@@ -2687,25 +2718,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-network-primitives"
-version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
-dependencies = [
- "actix",
- "borsh 0.8.2",
- "chrono",
- "near-crypto",
- "near-primitives",
- "serde",
- "strum",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "near-performance-metrics"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "bitflags",
@@ -2725,7 +2740,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "quote",
  "syn",
@@ -2734,7 +2749,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "near-crypto",
@@ -2745,7 +2760,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.8.2",
@@ -2758,7 +2773,7 @@ dependencies = [
  "jemallocator",
  "near-crypto",
  "near-primitives-core",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f)",
  "near-vm-errors 3.0.0",
  "num-rational 0.3.2",
  "primitive-types",
@@ -2775,7 +2790,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "base64 0.11.0",
  "borsh 0.8.2",
@@ -2806,7 +2821,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2831,9 +2846,9 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
- "near-rpc-error-core 0.1.0 (git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01)",
+ "near-rpc-error-core 0.1.0 (git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f)",
  "proc-macro2",
  "quote",
  "serde",
@@ -2917,7 +2932,7 @@ dependencies = [
 [[package]]
 name = "near-store"
 version = "2.2.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "byteorder",
@@ -2943,7 +2958,7 @@ dependencies = [
 [[package]]
 name = "near-telemetry"
 version = "0.1.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "actix-web",
@@ -2971,12 +2986,12 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "hex",
  "near-account-id",
- "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01)",
+ "near-rpc-error-macro 0.1.0 (git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f)",
  "serde",
 ]
 
@@ -2994,13 +3009,13 @@ dependencies = [
  "near-vm-errors 2.2.0",
  "serde",
  "sha2 0.8.2",
- "sha3 0.8.2",
+ "sha3",
 ]
 
 [[package]]
 name = "near-vm-logic"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.8.2",
@@ -3013,14 +3028,14 @@ dependencies = [
  "near-vm-errors 3.0.0",
  "ripemd160",
  "serde",
- "sha2 0.9.6",
- "sha3 0.9.1",
+ "sha2 0.8.2",
+ "sha3",
 ]
 
 [[package]]
 name = "near-vm-runner"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "anyhow",
  "borsh 0.8.2",
@@ -3047,12 +3062,11 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+version = "1.21.1"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "actix",
  "actix-rt",
- "actix-web",
  "actix_derive",
  "awc",
  "borsh 0.8.2",
@@ -3105,10 +3119,11 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "3.0.0"
-source = "git+https://github.com/near/nearcore?rev=13141b4b78b402734a83df41fc4b7feb5b7ced01#13141b4b78b402734a83df41fc4b7feb5b7ced01"
+source = "git+https://github.com/near/nearcore?rev=4dbc9f8bbe88c8d2b64a557ecae285fbe568710f#4dbc9f8bbe88c8d2b64a557ecae285fbe568710f"
 dependencies = [
  "borsh 0.8.2",
  "byteorder",
+ "ethereum-types",
  "hex",
  "lazy_static",
  "log",
@@ -3510,12 +3525,14 @@ dependencies = [
 
 [[package]]
 name = "primitive-types"
-version = "0.10.1"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
+checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
  "fixed-hash",
  "impl-codec",
+ "impl-rlp",
+ "impl-serde",
  "uint 0.9.1",
 ]
 
@@ -3958,6 +3975,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rlp"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4175,18 +4202,6 @@ dependencies = [
  "digest 0.8.1",
  "keccak",
  "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha3"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "keccak",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -4533,6 +4548,15 @@ dependencies = [
  "quote",
  "standback",
  "syn",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,6 @@ tracing-subscriber = "0.2.4"
 uint = { version = "0.8.3", default-features = false }
 
 actix-diesel = { git = "https://github.com/frol/actix-diesel", branch="actix-0.11-beta.2" }
-near-indexer = { git = "https://github.com/near/nearcore", rev="13141b4b78b402734a83df41fc4b7feb5b7ced01" }
-near-crypto = { git = "https://github.com/near/nearcore", rev="13141b4b78b402734a83df41fc4b7feb5b7ced01" }
-near-client = { git = "https://github.com/near/nearcore", rev="13141b4b78b402734a83df41fc4b7feb5b7ced01" }
+near-indexer = { git = "https://github.com/near/nearcore", rev="4dbc9f8bbe88c8d2b64a557ecae285fbe568710f" }
+near-crypto = { git = "https://github.com/near/nearcore", rev="4dbc9f8bbe88c8d2b64a557ecae285fbe568710f" }
+near-client = { git = "https://github.com/near/nearcore", rev="4dbc9f8bbe88c8d2b64a557ecae285fbe568710f" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Due to a fix being released to mainnet we need
this migration to be able to use the latest archive backups on mainnet.