### PR TITLE
doc: add select privilege by default to all users

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ We use `public` schema for all tables. By default, new users have the possibilit
 ```sql
 REVOKE CREATE ON SCHEMA PUBLIC FROM PUBLIC;
 REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA PUBLIC FROM PUBLIC;
+ALTER DEFAULT PRIVILEGES IN SCHEMA PUBLIC GRANT SELECT ON TABLES TO PUBLIC;
 ```
 
 After that, you could create read-only user in PostgreSQL:


### PR DESCRIPTION
I added it here as the migration
https://github.com/near/near-indexer-for-explorer/blob/master/migrations/2021-06-09-102523_grant_select_on_new_tables/up.sql

But I always forget to run it in all new DBs
I'm copy-pasting the code from here
It will be easier to fix the source 