### PR TITLE
fix: Long boot time on start from interruption was apparently due to the fact that we loaded all the blocks, ooops

### DIFF
--- a/src/db_adapters/blocks.rs
+++ b/src/db_adapters/blocks.rs
@@ -35,6 +35,7 @@ pub(crate) async fn latest_block_height(
     Ok(schema::blocks::table
         .select((schema::blocks::dsl::block_height,))
         .order(schema::blocks::dsl::block_height.desc())
+        .limit(1)
         .get_optional_result_async::<(bigdecimal::BigDecimal,)>(pool)
         .await
         .map_err(|err| format!("DB Error: {}", err))?


### PR DESCRIPTION
@khorolets There is no urgency at the moment, but the next time we would need to check something, let's check if this fix resolves the issue.