### PR TITLE
refactor: 0.10.4 (nearcore 1.23.0 + hash collisions solution)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.10.4
 
 * Upgrade `nearcore` to 1.23.0
+* Handle transaction hash collisions (issue #84)
 
 ## 0.10.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.10.4-rc.1"
+version = "0.10.4"
 dependencies = [
  "actix",
  "actix-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.4-rc.1"
+version = "0.10.4"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 


### PR DESCRIPTION
* Bump version to `0.10.4`
* #203 
* Fix `from-interruption` performance issue