### PR TITLE
refactor: Upgrade nearcore to 1.23.1-rc.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.5
+
+* Upgrade `nearcore` to 1.23.1-rc.1
+
 ## 0.10.4
 
 * Upgrade `nearcore` to 1.23.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.10.4"
+version = "0.10.5"
 dependencies = [
  "actix",
  "actix-diesel",
@@ -2222,7 +2222,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "serde",
@@ -2231,7 +2231,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "borsh 0.9.1",
@@ -2260,7 +2260,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "chrono",
  "derive_more",
@@ -2277,7 +2277,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "chrono",
  "failure",
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "borsh 0.9.1",
@@ -2315,7 +2315,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "near-chain-primitives",
 ]
@@ -2323,7 +2323,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2363,7 +2363,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "chrono",
@@ -2381,7 +2381,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2407,7 +2407,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "cached",
@@ -2429,7 +2429,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "async-recursion",
@@ -2450,7 +2450,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2477,7 +2477,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix-http",
  "awc",
@@ -2492,7 +2492,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "near-chain-configs",
@@ -2513,7 +2513,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "lazy_static",
  "log",
@@ -2523,7 +2523,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "borsh 0.9.1",
@@ -2557,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "near-network-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "borsh 0.9.1",
@@ -2573,7 +2573,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "bitflags",
@@ -2593,7 +2593,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "quote",
  "syn",
@@ -2602,7 +2602,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "near-crypto",
@@ -2613,7 +2613,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.9.1",
@@ -2641,7 +2641,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "base64 0.11.0",
  "borsh 0.9.1",
@@ -2675,7 +2675,7 @@ dependencies = [
 [[package]]
 name = "near-rate-limiter"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2688,7 +2688,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2712,7 +2712,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "near-rpc-error-core 0.0.0",
  "proc-macro2",
@@ -2790,12 +2790,12 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "byteorder",
@@ -2826,7 +2826,7 @@ source = "git+https://github.com/near/near-sdk-rs?rev=03487c184d37b0382dd9bd41c5
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "actix-web",
@@ -2843,7 +2843,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "hex",
@@ -2867,7 +2867,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.9.1",
@@ -2905,7 +2905,7 @@ dependencies = [
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "anyhow",
  "borsh 0.9.1",
@@ -2933,8 +2933,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "1.23.0-rc.1"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+version = "1.23.1-rc.1"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2995,7 +2995,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=397a7a45b8efd3e4604374a4efabd567c03c0a19#397a7a45b8efd3e4604374a4efabd567c03c0a19"
+source = "git+https://github.com/near/nearcore?rev=4807978dd6a952a25b2f304fb15433ea9480b39d#4807978dd6a952a25b2f304fb15433ea9480b39d"
 dependencies = [
  "borsh 0.9.1",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.4"
+version = "0.10.5"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -37,7 +37,7 @@ tracing = "0.1.13"
 tracing-subscriber = "0.2.4"
 uint = { version = "0.8.3", default-features = false }
 
-actix-diesel = { git = "https://github.com/frol/actix-diesel", branch="actix-0.11-beta.2" }
-near-indexer = { git = "https://github.com/near/nearcore", rev="397a7a45b8efd3e4604374a4efabd567c03c0a19" }
-near-crypto = { git = "https://github.com/near/nearcore", rev="397a7a45b8efd3e4604374a4efabd567c03c0a19" }
-near-client = { git = "https://github.com/near/nearcore", rev="397a7a45b8efd3e4604374a4efabd567c03c0a19" }
+actix-diesel = { git = "https://github.com/frol/actix-diesel", branch = "actix-0.11-beta.2" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "4807978dd6a952a25b2f304fb15433ea9480b39d" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "4807978dd6a952a25b2f304fb15433ea9480b39d" }
+near-client = { git = "https://github.com/near/nearcore", rev = "4807978dd6a952a25b2f304fb15433ea9480b39d" }


### PR DESCRIPTION
A protocol upgrade is going to happen in `1.23.1-rc.1` we need to follow to prevent our nodes from being stuck