### PR TITLE
refactor: Add ReceiptsCache to decrease the number of unnecessary SELECT queries to the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1884,6 +1884,7 @@ dependencies = [
  "base64 0.11.0",
  "bigdecimal",
  "borsh 0.7.2",
+ "cached",
  "chrono",
  "clap",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ anyhow = "1.0.51"
 base64 = "0.11"
 bigdecimal = "=0.1.0"
 borsh = "0.7.1"
+cached = "0.23.0"
 chrono = "0.4.19"
 clap = { version = "3.0.0-beta.5", features = ["color", "derive", "env"] }
 diesel = { version = "1.4.7", features = ["postgres", "numeric", "serde_json"] }

--- a/src/configs.rs
+++ b/src/configs.rs
@@ -17,6 +17,9 @@ pub(crate) struct Opts {
     /// Sets a custom config dir. Defaults to ~/.near/
     #[clap(short, long)]
     pub home_dir: Option<std::path::PathBuf>,
+    /// Enabled Indexer for Explorer debug level of logs
+    #[clap(long)]
+    pub debug: bool,
     #[clap(subcommand)]
     pub subcmd: SubCommand,
 }

--- a/src/db_adapters/execution_outcomes.rs
+++ b/src/db_adapters/execution_outcomes.rs
@@ -38,7 +38,8 @@ pub async fn store_execution_outcomes_for_chunk(
         vec![];
     for (index_in_chunk, outcome) in execution_outcomes.iter().enumerate() {
         // Trying to take the parent Transaction hash for the Receipt from ReceiptsCache
-        let parent_transaction_hash = receipts_cache_lock.remove(outcome.execution_outcome.id.to_string().as_str());
+        let parent_transaction_hash =
+            receipts_cache_lock.remove(outcome.execution_outcome.id.to_string().as_str());
 
         let model = models::execution_outcomes::ExecutionOutcome::from_execution_outcome(
             &outcome.execution_outcome,
@@ -55,15 +56,15 @@ pub async fn store_execution_outcomes_for_chunk(
                 .receipt_ids
                 .iter()
                 .enumerate()
-                .map(
-                    |(index, receipt_id)| {
-                        // if we have `parent_transaction_hash` from cache, then we put all "produced" Receipt IDs
-                        // as key and `parent_transaction_hash` as value, so the Receipts from one of the next blocks
-                        // could find their parents in cache
-                        if let Some(transaction_hash) = &parent_transaction_hash {
-                            receipts_cache_lock.insert(receipt_id.to_string(), transaction_hash.clone());
-                        }
-                        models::execution_outcomes::ExecutionOutcomeReceipt {
+                .map(|(index, receipt_id)| {
+                    // if we have `parent_transaction_hash` from cache, then we put all "produced" Receipt IDs
+                    // as key and `parent_transaction_hash` as value, so the Receipts from one of the next blocks
+                    // could find their parents in cache
+                    if let Some(transaction_hash) = &parent_transaction_hash {
+                        receipts_cache_lock
+                            .insert(receipt_id.to_string(), transaction_hash.clone());
+                    }
+                    models::execution_outcomes::ExecutionOutcomeReceipt {
                         executed_receipt_id: outcome.execution_outcome.id.to_string(),
                         index_in_execution_outcome: index as i32,
                         produced_receipt_id: receipt_id.to_string(),

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -123,22 +123,35 @@ async fn find_tx_hashes_for_receipts(
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
     chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
     receipts_cache: crate::ReceiptsCache,
-) -> anyhow::Result<HashMap<String, String>> {
-    let receipts_cache_lock = receipts_cache.lock().await;
+) -> anyhow::Result<HashMap<crate::ReceiptIdString, crate::ParentTransactionHashString>> {
+    let mut tx_hashes_for_receipts: HashMap<
+        crate::ReceiptIdString,
+        crate::ParentTransactionHashString,
+    > = HashMap::new();
 
-    let mut tx_hashes_for_receipts: HashMap<String, String> = HashMap::new();
-    //
-    tx_hashes_for_receipts.extend(
-        receipts_cache_lock
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone())),
-    );
+    let receipts_cache_lock = receipts_cache.lock().await;
+    // add receipt-transaction pairs from the cache to the response
+    tx_hashes_for_receipts.extend(receipts.iter().filter_map(|receipt| {
+        if let Some(parent_transaction_hash) =
+            receipts_cache_lock.get(receipt.receipt_id.to_string().as_str())
+        {
+            Some((
+                receipt.receipt_id.to_string(),
+                parent_transaction_hash.clone(),
+            ))
+        } else {
+            None
+        }
+    }));
+    // releasing the lock
+    drop(receipts_cache_lock);
 
     // discard the Receipts already in cache from the attempts to search
-    receipts.retain(|r| !receipts_cache_lock.contains_key(r.receipt_id.to_string().as_str()));
+    receipts.retain(|r| !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str()));
     if receipts.is_empty() {
         return Ok(tx_hashes_for_receipts);
     }
+
     warn!(
         target: crate::INDEXER_FOR_EXPLORER,
         "Looking for parent transaction hash in database for {} receipts",
@@ -159,7 +172,10 @@ async fn find_tx_hashes_for_receipts(
             .collect();
         if !data_ids.is_empty() {
             let mut interval = crate::INTERVAL;
-            let tx_hashes_for_data_id_via_data_output: Vec<(String, String)> = loop {
+            let tx_hashes_for_data_id_via_data_output: Vec<(
+                String,
+                crate::ParentTransactionHashString,
+            )> = loop {
                 match schema::action_receipt_output_data::table
                     .inner_join(
                         schema::receipts::table.on(
@@ -200,7 +216,10 @@ async fn find_tx_hashes_for_receipts(
                 HashMap::<String, String>::new();
             tx_hashes_for_data_id_via_data_output_hashmap
                 .extend(tx_hashes_for_data_id_via_data_output);
-            let tx_hashes_for_receipts_via_data_output: Vec<(String, String)> = receipts
+            let tx_hashes_for_receipts_via_data_output: Vec<(
+                crate::ReceiptIdString,
+                crate::ParentTransactionHashString,
+            )> = receipts
                 .iter()
                 .filter_map(|r| match r.receipt {
                     near_indexer::near_primitives::views::ReceiptEnumView::Data {
@@ -224,39 +243,39 @@ async fn find_tx_hashes_for_receipts(
             });
         }
 
-        let tx_hashes_for_receipts_via_outcomes: Vec<(String, String)> =
-            crate::await_retry_or_panic!(
-                schema::execution_outcome_receipts::table
-                    .inner_join(
-                        schema::receipts::table
-                            .on(schema::execution_outcome_receipts::dsl::executed_receipt_id
-                                .eq(schema::receipts::dsl::receipt_id)),
-                    )
-                    .filter(
-                        schema::execution_outcome_receipts::dsl::produced_receipt_id.eq(any(
-                            receipts
-                                .clone()
-                                .iter()
-                                .filter(|r| {
-                                    matches!(
+        let tx_hashes_for_receipts_via_outcomes: Vec<(
+            crate::ReceiptIdString,
+            crate::ParentTransactionHashString,
+        )> = crate::await_retry_or_panic!(
+            schema::execution_outcome_receipts::table
+                .inner_join(
+                    schema::receipts::table
+                        .on(schema::execution_outcome_receipts::dsl::executed_receipt_id
+                            .eq(schema::receipts::dsl::receipt_id)),
+                )
+                .filter(
+                    schema::execution_outcome_receipts::dsl::produced_receipt_id.eq(any(receipts
+                        .clone()
+                        .iter()
+                        .filter(|r| {
+                            matches!(
                                 r.receipt,
                                 near_indexer::near_primitives::views::ReceiptEnumView::Action { .. }
                             )
-                                })
-                                .map(|r| r.receipt_id.to_string())
-                                .collect::<Vec<String>>()
-                        )),
-                    )
-                    .select((
-                        schema::execution_outcome_receipts::dsl::produced_receipt_id,
-                        schema::receipts::dsl::originated_from_transaction_hash,
-                    ))
-                    .load_async::<(String, String)>(pool),
-                10,
-                "Parent Transaction for Receipts were fetched".to_string(),
-                &receipts
-            )
-            .unwrap_or_default();
+                        })
+                        .map(|r| r.receipt_id.to_string())
+                        .collect::<Vec<String>>())),
+                )
+                .select((
+                    schema::execution_outcome_receipts::dsl::produced_receipt_id,
+                    schema::receipts::dsl::originated_from_transaction_hash,
+                ))
+                .load_async::<(String, String)>(pool),
+            10,
+            "Parent Transaction for Receipts were fetched".to_string(),
+            &receipts
+        )
+        .unwrap_or_default();
 
         let found_hashes_len = tx_hashes_for_receipts_via_outcomes.len();
         tx_hashes_for_receipts.extend(tx_hashes_for_receipts_via_outcomes);
@@ -268,34 +287,34 @@ async fn find_tx_hashes_for_receipts(
         receipts
             .retain(|r| !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str()));
 
-        let tx_hashes_for_receipt_via_transactions: Vec<(String, String)> =
-            crate::await_retry_or_panic!(
-                schema::transactions::table
-                    .filter(
-                        schema::transactions::dsl::converted_into_receipt_id.eq(any(
-                            receipts
-                                .clone()
-                                .iter()
-                                .filter(|r| {
-                                    matches!(
+        let tx_hashes_for_receipt_via_transactions: Vec<(
+            crate::ReceiptIdString,
+            crate::ParentTransactionHashString,
+        )> = crate::await_retry_or_panic!(
+            schema::transactions::table
+                .filter(
+                    schema::transactions::dsl::converted_into_receipt_id.eq(any(receipts
+                        .clone()
+                        .iter()
+                        .filter(|r| {
+                            matches!(
                                 r.receipt,
                                 near_indexer::near_primitives::views::ReceiptEnumView::Action { .. }
                             )
-                                })
-                                .map(|r| r.receipt_id.to_string())
-                                .collect::<Vec<String>>()
-                        )),
-                    )
-                    .select((
-                        schema::transactions::dsl::converted_into_receipt_id,
-                        schema::transactions::dsl::transaction_hash,
-                    ))
-                    .load_async::<(String, String)>(pool),
-                10,
-                "Parent Transaction for ExecutionOutcome were fetched".to_string(),
-                &receipts
-            )
-            .unwrap_or_default();
+                        })
+                        .map(|r| r.receipt_id.to_string())
+                        .collect::<Vec<String>>())),
+                )
+                .select((
+                    schema::transactions::dsl::converted_into_receipt_id,
+                    schema::transactions::dsl::transaction_hash,
+                ))
+                .load_async::<(String, String)>(pool),
+            10,
+            "Parent Transaction for ExecutionOutcome were fetched".to_string(),
+            &receipts
+        )
+        .unwrap_or_default();
 
         let found_hashes_len = tx_hashes_for_receipt_via_transactions.len();
         tx_hashes_for_receipts.extend(tx_hashes_for_receipt_via_transactions);

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -89,11 +89,11 @@ pub(crate) async fn store_transactions(
 async fn collect_converted_to_receipt_ids(
     pool: &actix_diesel::Database<PgConnection>,
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
-) -> anyhow::Result<Vec<String>> {
+) -> anyhow::Result<Vec<crate::ReceiptIdString>> {
     Ok(schema::transactions::table
         .select(schema::transactions::dsl::converted_into_receipt_id)
         .filter(schema::transactions::dsl::included_in_block_hash.eq(block_hash.to_string()))
-        .get_results_async::<String>(pool)
+        .get_results_async::<crate::ReceiptIdString>(pool)
         .await
         .context("DB Error")?)
 }

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -1,5 +1,6 @@
 use actix_diesel::dsl::AsyncRunQueryDsl;
 use anyhow::Context;
+use cached::Cached;
 use diesel::{ExpressionMethods, PgConnection, QueryDsl};
 use futures::future::try_join_all;
 
@@ -127,7 +128,8 @@ async fn store_chunk_transactions(
             // and the Transaction hash as a value.
             // Later, while Receipt will be looking for a parent Transaction hash
             // it will be able to find it in the ReceiptsCache
-            receipts_cache_lock.insert(converted_into_receipt_id.clone(), transaction_hash.clone());
+            receipts_cache_lock
+                .cache_set(converted_into_receipt_id.clone(), transaction_hash.clone());
 
             models::transactions::Transaction::from_indexer_transaction(
                 tx,

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -15,6 +15,7 @@ pub(crate) async fn store_transactions(
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
     block_timestamp: u64,
     block_height: near_primitives::types::BlockHeight,
+    receipts_cache: crate::ReceiptsCache,
 ) -> anyhow::Result<()> {
     let mut tried_to_insert_transactions_count = 0;
     let tx_futures = shards
@@ -33,6 +34,7 @@ pub(crate) async fn store_transactions(
                 block_hash,
                 block_timestamp,
                 "",
+                receipts_cache.clone(),
             )
         });
 
@@ -76,6 +78,7 @@ pub(crate) async fn store_transactions(
                 block_hash,
                 block_timestamp,
                 &transaction_hash_suffix,
+                receipts_cache.clone(),
             )
         });
 
@@ -102,14 +105,37 @@ async fn store_chunk_transactions(
     block_timestamp: u64,
     // hack for supporting duplicated transaction hashes. Empty for most of transactions
     transaction_hash_suffix: &str,
+    receipts_cache: crate::ReceiptsCache,
 ) -> anyhow::Result<()> {
+    let mut receipts_cache_lock = receipts_cache.lock().await;
+
     let transaction_models: Vec<models::transactions::Transaction> = transactions
         .iter()
         .map(|(index, tx)| {
             let transaction_hash = tx.transaction.hash.to_string() + transaction_hash_suffix;
+            let converted_into_receipt_id = tx
+                .outcome
+                .execution_outcome
+                .outcome
+                .receipt_ids
+                .first()
+                .expect("`receipt_ids` must contain one Receipt Id")
+                .to_string();
+
+            // Save this Transaction hash to ReceiptsCache
+            // we use the Receipt ID to which this transaction was converted
+            // and the Transaction hash as a value.
+            // Later, while Receipt will be looking for a parent Transaction hash
+            // it will be able to find it in the ReceiptsCache
+            receipts_cache_lock.insert(
+                converted_into_receipt_id.clone(),
+                transaction_hash.clone(),
+            );
+
             models::transactions::Transaction::from_indexer_transaction(
                 tx,
                 &transaction_hash,
+                &converted_into_receipt_id,
                 block_hash,
                 chunk_hash,
                 block_timestamp,

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -141,6 +141,9 @@ async fn store_chunk_transactions(
         })
         .collect();
 
+    // releasing the lock
+    drop(receipts_cache_lock);
+
     crate::await_retry_or_panic!(
         diesel::insert_into(schema::transactions::table)
             .values(transaction_models.clone())

--- a/src/db_adapters/transactions.rs
+++ b/src/db_adapters/transactions.rs
@@ -127,10 +127,7 @@ async fn store_chunk_transactions(
             // and the Transaction hash as a value.
             // Later, while Receipt will be looking for a parent Transaction hash
             // it will be able to find it in the ReceiptsCache
-            receipts_cache_lock.insert(
-                converted_into_receipt_id.clone(),
-                transaction_hash.clone(),
-            );
+            receipts_cache_lock.insert(converted_into_receipt_id.clone(), transaction_hash.clone());
 
             models::transactions::Transaction::from_indexer_transaction(
                 tx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use std::convert::TryFrom;
+use std::collections::HashMap;
 #[macro_use]
 extern crate diesel;
 
@@ -7,8 +8,8 @@ use actix_diesel::Database;
 use diesel::PgConnection;
 use futures::future::try_join_all;
 use futures::{try_join, StreamExt};
-use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tokio::sync::{mpsc, Mutex};
+use tracing::{info, warn, debug};
 use tracing_subscriber::EnvFilter;
 
 use crate::configs::{Opts, SubCommand};
@@ -28,11 +29,17 @@ const AGGREGATED: &str = "aggregated";
 const INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_DELAY_TIME: std::time::Duration = std::time::Duration::from_secs(120);
 
+// Introducing a simple cache for Receipts to find their parent Transactions without
+// touching the database
+pub type ReceiptsCache = std::sync::Arc<Mutex<HashMap<String, String>>>;
+
 async fn handle_message(
     pool: &actix_diesel::Database<PgConnection>,
     streamer_message: near_indexer::StreamerMessage,
     strict_mode: bool,
+    receipts_cache: ReceiptsCache,
 ) -> anyhow::Result<()> {
+    debug!(target: INDEXER_FOR_EXPLORER, "ReceiptsCache #{} \n {:#?}", streamer_message.block.header.height, &receipts_cache);
     db_adapters::blocks::store_block(pool, &streamer_message.block).await?;
 
     // Chunks
@@ -50,6 +57,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         streamer_message.block.header.height,
+        std::sync::Arc::clone(&receipts_cache),
     );
 
     // Receipts
@@ -59,6 +67,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         strict_mode,
+        std::sync::Arc::clone(&receipts_cache),
     );
 
     // We can process transactions and receipts in parallel
@@ -73,6 +82,7 @@ async fn handle_message(
         pool,
         &streamer_message.shards,
         streamer_message.block.header.timestamp,
+        std::sync::Arc::clone(&receipts_cache),
     );
 
     // Accounts
@@ -151,13 +161,21 @@ async fn listen_blocks(
         );
     }
     info!(target: crate::INDEXER_FOR_EXPLORER, "Stream has started");
+
+    // We want to prevent unnecessary SELECT queries to the database to find
+    // the Transaction hash for the Receipt.
+    // Later we need to find the Receipt which is a parent to underlying Receipts.
+    // Receipt ID will of the child will be stored as key and parent Transaction hash/Receipt ID
+    // will be stored as a value
+    let receipts_cache: ReceiptsCache = std::sync::Arc::new(Mutex::new(HashMap::new()));
+
     let handle_messages =
         tokio_stream::wrappers::ReceiverStream::new(stream).map(|streamer_message| {
             info!(
                 target: crate::INDEXER_FOR_EXPLORER,
                 "Block height {}", &streamer_message.block.header.height
             );
-            handle_message(&pool, streamer_message, strict_mode)
+            handle_message(&pool, streamer_message, strict_mode, std::sync::Arc::clone(&receipts_cache))
         });
     let mut handle_messages = if let Some(stop_after_n_blocks) = stop_after_number_of_blocks {
         handle_messages
@@ -245,9 +263,17 @@ fn main() {
     // Indexer should fail if .env file with credentials is missing/wrong
     let pool = models::establish_connection();
 
+    let opts: Opts = Opts::parse();
+
     let mut env_filter = EnvFilter::new(
-        "tokio_reactor=info,near=info,stats=info,telemetry=info,indexer=info,indexer_for_explorer=info,aggregated=info",
+        "tokio_reactor=info,near=info,stats=info,telemetry=info,indexer=info,aggregated=info"
     );
+
+    if opts.debug {
+        env_filter = env_filter.add_directive("indexer_for_explorer=debug".parse().expect("Failed to parse directive"));
+    } else {
+        env_filter = env_filter.add_directive("indexer_for_explorer=info".parse().expect("Failed to parse directive"));
+    };
 
     if let Ok(rust_log) = std::env::var("RUST_LOG") {
         if !rust_log.is_empty() {
@@ -267,8 +293,6 @@ fn main() {
         .with_env_filter(env_filter)
         .with_writer(std::io::stderr)
         .init();
-
-    let opts: Opts = Opts::parse();
 
     let home_dir = opts.home_dir.unwrap_or_else(near_indexer::get_default_home);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,15 @@ const AGGREGATED: &str = "aggregated";
 const INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_DELAY_TIME: std::time::Duration = std::time::Duration::from_secs(120);
 
+// Creating type aliases to make HashMap types for cache more explicit
+pub type ReceiptIdString = String;
+pub type ParentTransactionHashString = String;
 // Introducing a simple cache for Receipts to find their parent Transactions without
 // touching the database
-pub type ReceiptsCache = std::sync::Arc<Mutex<HashMap<String, String>>>;
+// The key is ReceiptID
+// The value is TransactionHash (the very parent of the Receipt)
+pub type ReceiptsCache =
+    std::sync::Arc<Mutex<HashMap<ReceiptIdString, ParentTransactionHashString>>>;
 
 async fn handle_message(
     pool: &actix_diesel::Database<PgConnection>,

--- a/src/models/transactions.rs
+++ b/src/models/transactions.rs
@@ -29,6 +29,7 @@ impl Transaction {
         tx: &near_indexer::IndexerTransactionWithOutcome,
         // hack for supporting duplicated transaction hashes
         transaction_hash: &str,
+        converted_into_receipt_id: &str,
         block_hash: &near_indexer::near_primitives::hash::CryptoHash,
         chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
         block_timestamp: u64,
@@ -44,14 +45,7 @@ impl Transaction {
             signer_public_key: tx.transaction.public_key.to_string(),
             signature: tx.transaction.signature.to_string(),
             receiver_account_id: tx.transaction.receiver_id.to_string(),
-            converted_into_receipt_id: tx
-                .outcome
-                .execution_outcome
-                .outcome
-                .receipt_ids
-                .first()
-                .expect("`receipt_ids` must contain one Receipt Id")
-                .to_string(),
+            converted_into_receipt_id: converted_into_receipt_id.to_string(),
             included_in_chunk_hash: chunk_hash.to_string(),
             status: tx.outcome.execution_outcome.outcome.status.clone().into(),
             receipt_conversion_gas_burnt: tx.outcome.execution_outcome.outcome.gas_burnt.into(),


### PR DESCRIPTION
Resolves #229 

* I've added the `--debug` flag and the first `indexer_for_explorer` debug message to reason about how the cache is working, it should allow us to put some more logs if needed
* Add `ReceiptCache` which is a `HashMap` of accordance between Receipt ID and parent Transaction hash. 
  The working flow looks like this:
  * First we handle transactions and we store the pair `converted_into_receipt_id: transaction_hash` to the cache
  * When processing receipts we look into the cache to get a parent transaction hash for each of the receipts
    * [Fallback logic] If we don't observe parent transaction hash for specific receipts we are looking for them in the database
  * ExecutionOutcomes stage. We are interested in those outcomes that result in another receipt(s). We get all those receipts' ids and we take the parent transaction hash for the original receipt from the cache. Then we put `receipt_id: transaction_hash` for each of the new receipts.