### PR TITLE
refactor: Improve ReceiptsCache to handle Data Receipts and some optimization

### DIFF
--- a/src/db_adapters/execution_outcomes.rs
+++ b/src/db_adapters/execution_outcomes.rs
@@ -41,8 +41,9 @@ pub async fn store_execution_outcomes_for_chunk(
         // Trying to take the parent Transaction hash for the Receipt from ReceiptsCache
         // remove it from cache once found as it is not expected to observe the Receipt for
         // second time
-        let parent_transaction_hash =
-            receipts_cache_lock.cache_remove(&outcome.execution_outcome.id.to_string());
+        let parent_transaction_hash = receipts_cache_lock.cache_remove(
+            &crate::ReceiptOrDataId::ReceiptId(outcome.execution_outcome.id),
+        );
 
         let model = models::execution_outcomes::ExecutionOutcome::from_execution_outcome(
             &outcome.execution_outcome,
@@ -64,8 +65,10 @@ pub async fn store_execution_outcomes_for_chunk(
                     // as key and `parent_transaction_hash` as value, so the Receipts from one of the next blocks
                     // could find their parents in cache
                     if let Some(transaction_hash) = &parent_transaction_hash {
-                        receipts_cache_lock
-                            .cache_set(receipt_id.to_string(), transaction_hash.clone());
+                        receipts_cache_lock.cache_set(
+                            crate::ReceiptOrDataId::ReceiptId(*receipt_id),
+                            transaction_hash.clone(),
+                        );
                     }
                     models::execution_outcomes::ExecutionOutcomeReceipt {
                         executed_receipt_id: outcome.execution_outcome.id.to_string(),

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -76,10 +76,15 @@ async fn store_chunk_receipts(
             // depending on the Receipt kind
             // In case of Action Receipt we are looking for ReceiptId
             // In case of Data Receipt we are looking for DataId
-            match r.receipt {
+            let receipt_or_data_id = match r.receipt {
                 near_primitives::views::ReceiptEnumView::Action { .. } => {
-                    if let Some(transaction_hash) =
-                    tx_hashes_for_receipts.get(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
+                    crate::ReceiptOrDataId::ReceiptId(r.receipt_id)
+                }
+                near_primitives::views::ReceiptEnumView::Data { data_id, .. } => {
+                    crate::ReceiptOrDataId::DataId(data_id)
+                }
+            };
+            if let Some(transaction_hash) = tx_hashes_for_receipts.get(&receipt_or_data_id) {
                     {
                         Some(models::Receipt::from_receipt_view(
                             r,

--- a/src/db_adapters/receipts.rs
+++ b/src/db_adapters/receipts.rs
@@ -1,5 +1,8 @@
 use std::collections::HashMap;
 use std::convert::TryFrom;
+use std::str::FromStr;
+
+use near_indexer::near_primitives;
 
 use actix_diesel::dsl::AsyncRunQueryDsl;
 use cached::Cached;
@@ -69,30 +72,89 @@ async fn store_chunk_receipts(
         .iter()
         .enumerate()
         .filter_map(|(index, r)| {
-            if let Some(transaction_hash) =
-            tx_hashes_for_receipts.get(r.receipt_id.to_string().as_str())
-            {
-                Some(models::Receipt::from_receipt_view(
-                    r,
-                    block_hash,
-                    transaction_hash,
-                    chunk_hash,
-                    index as i32,
-                    block_timestamp,
-                ))
-            } else {
-                warn!(
-                    target: crate::INDEXER_FOR_EXPLORER,
-                    "Skipping Receipt {} as we can't find parent Transaction for it. Happen in block hash {}, chunk hash {}",
-                    r.receipt_id.to_string(),
-                    block_hash,
-                    chunk_hash,
-                );
-                skipping_receipt_ids.insert(r.receipt_id);
-                None
+            // We need to search for parent transaction hash in cache differently
+            // depending on the Receipt kind
+            // In case of Action Receipt we are looking for ReceiptId
+            // In case of Data Receipt we are looking for DataId
+            match r.receipt {
+                near_primitives::views::ReceiptEnumView::Action { .. } => {
+                    if let Some(transaction_hash) =
+                    tx_hashes_for_receipts.get(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
+                    {
+                        Some(models::Receipt::from_receipt_view(
+                            r,
+                            block_hash,
+                            transaction_hash,
+                            chunk_hash,
+                            index as i32,
+                            block_timestamp,
+                        ))
+                    } else {
+                        warn!(
+                            target: crate::INDEXER_FOR_EXPLORER,
+                            "Skipping Receipt {} as we can't find parent Transaction for it. Happen in block hash {}, chunk hash {}",
+                            r.receipt_id.to_string(),
+                            block_hash,
+                            chunk_hash,
+                        );
+                        skipping_receipt_ids.insert(r.receipt_id);
+                        None
+                    }
+                }
+                near_primitives::views::ReceiptEnumView::Data { data_id, .. } => {
+                    if let Some(transaction_hash) =
+                    tx_hashes_for_receipts.get(&crate::ReceiptOrDataId::DataId(data_id))
+                    {
+                        Some(models::Receipt::from_receipt_view(
+                            r,
+                            block_hash,
+                            transaction_hash,
+                            chunk_hash,
+                            index as i32,
+                            block_timestamp,
+                        ))
+                    } else {
+                        warn!(
+                            target: crate::INDEXER_FOR_EXPLORER,
+                            "Skipping Receipt {} as we can't find parent Transaction for it. Happen in block hash {}, chunk hash {}",
+                            r.receipt_id.to_string(),
+                            block_hash,
+                            chunk_hash,
+                        );
+                        skipping_receipt_ids.insert(r.receipt_id);
+                        None
+                    }
+                }
             }
         })
         .collect();
+
+    // At the moment we can observe output data in the Receipt it's impossible to know
+    // the Receipt Id of that Data Receipt. That's why we insert the pair DataId<>ParentTransactionHash
+    // to ReceiptsCache
+    let mut receipts_cache_lock = receipts_cache.lock().await;
+    for receipt in receipts {
+        if let near_primitives::views::ReceiptEnumView::Action {
+            output_data_receivers,
+            ..
+        } = &receipt.receipt
+        {
+            if !output_data_receivers.is_empty() {
+                if let Some(transaction_hash) = tx_hashes_for_receipts
+                    .get(&crate::ReceiptOrDataId::ReceiptId(receipt.receipt_id))
+                {
+                    for data_receiver in output_data_receivers {
+                        receipts_cache_lock.cache_set(
+                            crate::ReceiptOrDataId::DataId(data_receiver.data_id),
+                            transaction_hash.clone(),
+                        );
+                    }
+                }
+            }
+        }
+    }
+    // releasing the lock
+    drop(receipts_cache_lock);
 
     save_receipts(pool, receipt_models).await?;
 
@@ -126,37 +188,59 @@ async fn find_tx_hashes_for_receipts(
     block_hash: &near_indexer::near_primitives::hash::CryptoHash,
     chunk_hash: &near_indexer::near_primitives::hash::CryptoHash,
     receipts_cache: crate::ReceiptsCache,
-) -> anyhow::Result<HashMap<crate::ReceiptIdString, crate::ParentTransactionHashString>> {
+) -> anyhow::Result<HashMap<crate::ReceiptOrDataId, crate::ParentTransactionHashString>> {
     let mut tx_hashes_for_receipts: HashMap<
-        crate::ReceiptIdString,
+        crate::ReceiptOrDataId,
         crate::ParentTransactionHashString,
     > = HashMap::new();
 
     let mut receipts_cache_lock = receipts_cache.lock().await;
     // add receipt-transaction pairs from the cache to the response
     tx_hashes_for_receipts.extend(receipts.iter().filter_map(|receipt| {
-        receipts_cache_lock
-            .cache_get(&receipt.receipt_id.to_string())
-            .map(|parent_transaction_hash| {
-                (
-                    receipt.receipt_id.to_string(),
-                    parent_transaction_hash.clone(),
-                )
-            })
+        match receipt.receipt {
+            near_primitives::views::ReceiptEnumView::Action { .. } => receipts_cache_lock
+                .cache_get(&crate::ReceiptOrDataId::ReceiptId(receipt.receipt_id))
+                .map(|parent_transaction_hash| {
+                    (
+                        crate::ReceiptOrDataId::ReceiptId(receipt.receipt_id),
+                        parent_transaction_hash.clone(),
+                    )
+                }),
+            near_primitives::views::ReceiptEnumView::Data { data_id, .. } => {
+                // Pair DataId:ParentTransactionHash won't be used after this moment
+                // We want to clean it up to prevent our cache from growing
+                receipts_cache_lock
+                    .cache_remove(&crate::ReceiptOrDataId::DataId(data_id))
+                    .map(|parent_transaction_hash| {
+                        (
+                            crate::ReceiptOrDataId::DataId(data_id),
+                            parent_transaction_hash,
+                        )
+                    })
+            }
+        }
     }));
     // releasing the lock
     drop(receipts_cache_lock);
 
     // discard the Receipts already in cache from the attempts to search
-    receipts.retain(|r| !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str()));
+    receipts.retain(|r| match r.receipt {
+        near_primitives::views::ReceiptEnumView::Data { data_id, .. } => {
+            !tx_hashes_for_receipts.contains_key(&crate::ReceiptOrDataId::DataId(data_id))
+        }
+        near_primitives::views::ReceiptEnumView::Action { .. } => {
+            !tx_hashes_for_receipts.contains_key(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
+        }
+    });
     if receipts.is_empty() {
         return Ok(tx_hashes_for_receipts);
     }
 
     warn!(
         target: crate::INDEXER_FOR_EXPLORER,
-        "Looking for parent transaction hash in database for {} receipts",
-        &receipts.len()
+        "Looking for parent transaction hash in database for {} receipts {:#?}",
+        &receipts.len(),
+        &receipts,
     );
 
     let mut retries_left: u8 = 4; // retry at least times even in no-strict mode to avoid data loss
@@ -174,7 +258,7 @@ async fn find_tx_hashes_for_receipts(
         if !data_ids.is_empty() {
             let mut interval = crate::INTERVAL;
             let tx_hashes_for_data_id_via_data_output: Vec<(
-                ReceiptDataIdString,
+                crate::ReceiptOrDataId,
                 crate::ParentTransactionHashString,
             )> = loop {
                 match schema::action_receipt_output_data::table
@@ -196,7 +280,22 @@ async fn find_tx_hashes_for_receipts(
                     .await
                 {
                     Ok(res) => {
-                        break res;
+                        break res
+                            .into_iter()
+                            .map(
+                                |(receipt_id_string, transaction_hash_string): (String, String)| {
+                                    (
+                                        crate::ReceiptOrDataId::ReceiptId(
+                                            near_primitives::hash::CryptoHash::from_str(
+                                                &receipt_id_string,
+                                            )
+                                            .expect("Failed to convert String to CryptoHash"),
+                                        ),
+                                        transaction_hash_string,
+                                    )
+                                },
+                            )
+                            .collect();
                     }
                     Err(async_error) => {
                         error!(
@@ -214,11 +313,11 @@ async fn find_tx_hashes_for_receipts(
             };
 
             let mut tx_hashes_for_data_id_via_data_output_hashmap =
-                HashMap::<crate::ReceiptIdString, crate::ParentTransactionHashString>::new();
+                HashMap::<crate::ReceiptOrDataId, crate::ParentTransactionHashString>::new();
             tx_hashes_for_data_id_via_data_output_hashmap
                 .extend(tx_hashes_for_data_id_via_data_output);
             let tx_hashes_for_receipts_via_data_output: Vec<(
-                crate::ReceiptIdString,
+                crate::ReceiptOrDataId,
                 crate::ParentTransactionHashString,
             )> = receipts
                 .iter()
@@ -226,8 +325,13 @@ async fn find_tx_hashes_for_receipts(
                     near_indexer::near_primitives::views::ReceiptEnumView::Data {
                         data_id, ..
                     } => tx_hashes_for_data_id_via_data_output_hashmap
-                        .get(data_id.to_string().as_str())
-                        .map(|tx_hash| (r.receipt_id.to_string(), tx_hash.to_string())),
+                        .get(&crate::ReceiptOrDataId::DataId(data_id))
+                        .map(|tx_hash| {
+                            (
+                                crate::ReceiptOrDataId::ReceiptId(r.receipt_id),
+                                tx_hash.to_string(),
+                            )
+                        }),
                     _ => None,
                 })
                 .collect();
@@ -240,56 +344,68 @@ async fn find_tx_hashes_for_receipts(
             }
 
             receipts.retain(|r| {
-                !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str())
+                !tx_hashes_for_receipts
+                    .contains_key(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
             });
         }
 
-        let tx_hashes_for_receipts_via_outcomes: Vec<(
-            crate::ReceiptIdString,
-            crate::ParentTransactionHashString,
-        )> = crate::await_retry_or_panic!(
-            schema::execution_outcome_receipts::table
-                .inner_join(
-                    schema::receipts::table
-                        .on(schema::execution_outcome_receipts::dsl::executed_receipt_id
-                            .eq(schema::receipts::dsl::receipt_id)),
-                )
-                .filter(
-                    schema::execution_outcome_receipts::dsl::produced_receipt_id.eq(any(receipts
-                        .clone()
-                        .iter()
-                        .filter(|r| {
-                            matches!(
+        let tx_hashes_for_receipts_via_outcomes: Vec<(String, crate::ParentTransactionHashString)> =
+            crate::await_retry_or_panic!(
+                schema::execution_outcome_receipts::table
+                    .inner_join(
+                        schema::receipts::table
+                            .on(schema::execution_outcome_receipts::dsl::executed_receipt_id
+                                .eq(schema::receipts::dsl::receipt_id)),
+                    )
+                    .filter(
+                        schema::execution_outcome_receipts::dsl::produced_receipt_id.eq(any(
+                            receipts
+                                .clone()
+                                .iter()
+                                .filter(|r| {
+                                    matches!(
                                 r.receipt,
                                 near_indexer::near_primitives::views::ReceiptEnumView::Action { .. }
                             )
-                        })
-                        .map(|r| r.receipt_id.to_string())
-                        .collect::<Vec<crate::ReceiptIdString>>())),
-                )
-                .select((
-                    schema::execution_outcome_receipts::dsl::produced_receipt_id,
-                    schema::receipts::dsl::originated_from_transaction_hash,
-                ))
-                .load_async::<(crate::ReceiptIdString, crate::ParentTransactionHashString)>(pool),
-            10,
-            "Parent Transaction for Receipts were fetched".to_string(),
-            &receipts
-        )
-        .unwrap_or_default();
+                                })
+                                .map(|r| r.receipt_id.to_string())
+                                .collect::<Vec<String>>()
+                        )),
+                    )
+                    .select((
+                        schema::execution_outcome_receipts::dsl::produced_receipt_id,
+                        schema::receipts::dsl::originated_from_transaction_hash,
+                    ))
+                    .load_async::<(String, crate::ParentTransactionHashString)>(pool),
+                10,
+                "Parent Transaction for Receipts were fetched".to_string(),
+                &receipts
+            )
+            .unwrap_or_default();
 
         let found_hashes_len = tx_hashes_for_receipts_via_outcomes.len();
-        tx_hashes_for_receipts.extend(tx_hashes_for_receipts_via_outcomes);
+        tx_hashes_for_receipts.extend(tx_hashes_for_receipts_via_outcomes.into_iter().map(
+            |(receipt_id_string, transaction_hash_string)| {
+                (
+                    crate::ReceiptOrDataId::ReceiptId(
+                        near_primitives::hash::CryptoHash::from_str(&receipt_id_string)
+                            .expect("Failed to convert String to CryptoHash"),
+                    ),
+                    transaction_hash_string,
+                )
+            },
+        ));
 
         if found_hashes_len == receipts.len() {
             break;
         }
 
-        receipts
-            .retain(|r| !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str()));
+        receipts.retain(|r| {
+            !tx_hashes_for_receipts.contains_key(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
+        });
 
         let tx_hashes_for_receipt_via_transactions: Vec<(
-            crate::ReceiptIdString,
+            String,
             crate::ParentTransactionHashString,
         )> = crate::await_retry_or_panic!(
             schema::transactions::table
@@ -304,13 +420,13 @@ async fn find_tx_hashes_for_receipts(
                             )
                         })
                         .map(|r| r.receipt_id.to_string())
-                        .collect::<Vec<crate::ReceiptIdString>>())),
+                        .collect::<Vec<String>>())),
                 )
                 .select((
                     schema::transactions::dsl::converted_into_receipt_id,
                     schema::transactions::dsl::transaction_hash,
                 ))
-                .load_async::<(crate::ReceiptIdString, crate::ParentTransactionHashString)>(pool),
+                .load_async::<(String, crate::ParentTransactionHashString)>(pool),
             10,
             "Parent Transaction for ExecutionOutcome were fetched".to_string(),
             &receipts
@@ -318,14 +434,25 @@ async fn find_tx_hashes_for_receipts(
         .unwrap_or_default();
 
         let found_hashes_len = tx_hashes_for_receipt_via_transactions.len();
-        tx_hashes_for_receipts.extend(tx_hashes_for_receipt_via_transactions);
+        tx_hashes_for_receipts.extend(tx_hashes_for_receipt_via_transactions.into_iter().map(
+            |(receipt_id_string, transaction_hash_string)| {
+                (
+                    crate::ReceiptOrDataId::ReceiptId(
+                        near_primitives::hash::CryptoHash::from_str(&receipt_id_string)
+                            .expect("Failed to convert String to CryptoHash"),
+                    ),
+                    transaction_hash_string,
+                )
+            },
+        ));
 
         if found_hashes_len == receipts.len() {
             break;
         }
 
-        receipts
-            .retain(|r| !tx_hashes_for_receipts.contains_key(r.receipt_id.to_string().as_str()));
+        receipts.retain(|r| {
+            !tx_hashes_for_receipts.contains_key(&crate::ReceiptOrDataId::ReceiptId(r.receipt_id))
+        });
 
         if !strict_mode {
             if retries_left > 0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,15 +29,19 @@ const AGGREGATED: &str = "aggregated";
 const INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
 const MAX_DELAY_TIME: std::time::Duration = std::time::Duration::from_secs(120);
 
+#[derive(Clone, Hash, PartialEq, Eq, Debug)]
+pub enum ReceiptOrDataId {
+    ReceiptId(near_indexer::near_primitives::hash::CryptoHash),
+    DataId(near_indexer::near_primitives::hash::CryptoHash),
+}
 // Creating type aliases to make HashMap types for cache more explicit
-pub type ReceiptIdString = String;
 pub type ParentTransactionHashString = String;
 // Introducing a simple cache for Receipts to find their parent Transactions without
 // touching the database
 // The key is ReceiptID
 // The value is TransactionHash (the very parent of the Receipt)
 pub type ReceiptsCache =
-    std::sync::Arc<Mutex<SizedCache<ReceiptIdString, ParentTransactionHashString>>>;
+    std::sync::Arc<Mutex<SizedCache<ReceiptOrDataId, ParentTransactionHashString>>>;
 
 async fn handle_message(
     pool: &actix_diesel::Database<PgConnection>,


### PR DESCRIPTION
Resolves #242 
* Replace type alias `ReceiptIdString` with `ReceiptOrDataId` enum
* Cache parent transaction hash for Data Receipts (it is necessary to do in a different way)