### PR TITLE
docs: Fix broken links to backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,11 +171,7 @@ Whenever you run NEAR Indexer for Explorer for any network except localnet you'l
 
 Running your NEAR Indexer for Explorer node on top of a backup data will reduce the time of syncing process because your node will download only missing data and it will take reasonable time.
 
-All the backups can be downloaded from the public S3 bucket which contains latest daily snapshots:
-
-* [Recent 5-epoch Mainnet data folder](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/rpc/data.tar)
-* [Recent 5-epoch Testnet data folder](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/rpc/data.tar)
-
+All the backups can be downloaded from the public S3 bucket which contains latest daily snapshots following the instruction [here](https://near-nodes.io/intro/node-data-snapshots).
 
 ## Running NEAR Indexer for Explorer as archival node
 
@@ -196,10 +192,7 @@ Find next keys in the config and update them as following:
 
 The syncing process in archival mode can take a lot of time, so it's better to download a backup provided by NEAR and put it in your `data` folder. After that your node will need to sync only missing data and it should take reasonable time.
 
-All the backups can be downloaded from the public S3 bucket which contains latest daily snapshots:
-
-* [Archival Mainnet data folder](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/mainnet/archive/data.tar)
-* [Archival Testnet data folder](https://near-protocol-public.s3-accelerate.amazonaws.com/backups/testnet/archive/data.tar)
+All the backups can be downloaded from the public S3 bucket which contains latest daily snapshots following the instruction [here](https://near-nodes.io/intro/node-data-snapshots).
 
 See https://docs.near.org/docs/roles/integrator/exchange-integration#running-an-archival-node for reference
 


### PR DESCRIPTION
@khorolets I used the link containing all 4 options (test/mainnet, rpc/archival), which is more likely to be up-to-date compared to other links like from bootcamp articles.