### PR TITLE
fix: dropped the args_json->amount index on action_receipt_actions table

### DIFF
--- a/migrations/2022-06-07-000000_drop_action_receipt_actions_args_amount_index/down.sql
+++ b/migrations/2022-06-07-000000_drop_action_receipt_actions_args_amount_index/down.sql
@@ -1,0 +1,2 @@
+CREATE INDEX action_receipt_actions_args_amount_idx ON action_receipt_actions((args->'args_json'->>'amount'))
+    WHERE action_receipt_actions.action_kind = 'FUNCTION_CALL' AND (action_receipt_actions.args->>'args_json') IS NOT NULL;

--- a/migrations/2022-06-07-000000_drop_action_receipt_actions_args_amount_index/up.sql
+++ b/migrations/2022-06-07-000000_drop_action_receipt_actions_args_amount_index/up.sql
@@ -1,0 +1,1 @@
+DROP INDEX action_receipt_actions_args_amount_idx;


### PR DESCRIPTION
Reverting `action_receipt_actions_args_amount_idx` index that was added in #99. This is needed to avoid potential problems when the `amount` argument in the receipt actions is not indexable.