### PR TITLE
release: indexer-for-explorer 0.10.24 with nearcore updated to 1.29.0-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.24
+
+* Upgrade `nearcore` to [`1.29.0-rc.2`](https://github.com/near/nearcore/releases/tag/1.29.0-rc.2) (according to nearcore release notes, it will require 3GB more RAM than before)
+
 ## 0.10.23
 
 * Fix the way we get `sha256` of the deployed contract code according to the changes introduced in `nearcore 1.29.0-rc.1`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 [[package]]
 name = "delay-detector"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "cpu-time",
  "tracing",
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.10.23"
+version = "0.10.24"
 dependencies = [
  "actix",
  "actix-diesel",
@@ -2401,7 +2401,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "serde",
@@ -2410,7 +2410,7 @@ dependencies = [
 [[package]]
 name = "near-cache"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "lru",
 ]
@@ -2418,7 +2418,7 @@ dependencies = [
 [[package]]
 name = "near-chain"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "ansi_term",
@@ -2451,7 +2451,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2469,7 +2469,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "chrono",
  "near-crypto",
@@ -2481,7 +2481,7 @@ dependencies = [
 [[package]]
 name = "near-chunks"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "borsh 0.9.3",
@@ -2506,7 +2506,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-chain-primitives",
  "near-primitives",
@@ -2515,7 +2515,7 @@ dependencies = [
 [[package]]
 name = "near-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "actix-rt",
@@ -2557,7 +2557,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "chrono",
@@ -2576,7 +2576,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "arrayref",
  "blake2",
@@ -2601,7 +2601,7 @@ dependencies = [
 [[package]]
 name = "near-epoch-manager"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "near-cache",
@@ -2622,7 +2622,7 @@ dependencies = [
 [[package]]
 name = "near-indexer"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "anyhow",
@@ -2646,7 +2646,7 @@ dependencies = [
 [[package]]
 name = "near-indexer-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-primitives",
  "serde",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2685,7 +2685,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix-http",
  "awc",
@@ -2700,7 +2700,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-chain-configs",
  "near-client-primitives",
@@ -2716,7 +2716,7 @@ dependencies = [
 [[package]]
 name = "near-logger-utils"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-o11y",
  "tracing",
@@ -2725,7 +2725,7 @@ dependencies = [
 [[package]]
 name = "near-mainnet-res"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
@@ -2736,7 +2736,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "prometheus",
  "tracing",
@@ -2745,7 +2745,7 @@ dependencies = [
 [[package]]
 name = "near-network"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "anyhow",
@@ -2796,7 +2796,7 @@ dependencies = [
 [[package]]
 name = "near-network-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "anyhow",
@@ -2817,7 +2817,7 @@ dependencies = [
 [[package]]
 name = "near-o11y"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "atty",
  "backtrace",
@@ -2838,7 +2838,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "bitflags",
@@ -2855,7 +2855,7 @@ dependencies = [
 [[package]]
 name = "near-performance-metrics-macros"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "quote",
  "syn",
@@ -2864,7 +2864,7 @@ dependencies = [
 [[package]]
 name = "near-pool"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "near-crypto",
@@ -2877,7 +2877,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "byteorder",
@@ -2906,7 +2906,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "base64 0.13.0",
  "borsh 0.9.3",
@@ -2941,7 +2941,7 @@ dependencies = [
 [[package]]
 name = "near-rate-limiter"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "bytes",
@@ -2955,7 +2955,7 @@ dependencies = [
 [[package]]
 name = "near-rosetta-rpc"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "actix-cors",
@@ -2983,7 +2983,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "quote",
  "serde",
@@ -3006,7 +3006,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "near-rpc-error-core 0.0.0",
  "serde",
@@ -3068,12 +3068,12 @@ dependencies = [
 [[package]]
 name = "near-stable-hasher"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 
 [[package]]
 name = "near-store"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "byteorder",
@@ -3108,7 +3108,7 @@ source = "git+https://github.com/near/near-sdk-rs?rev=03487c184d37b0382dd9bd41c5
 [[package]]
 name = "near-telemetry"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "awc",
@@ -3127,7 +3127,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "near-account-id",
@@ -3150,7 +3150,7 @@ dependencies = [
 [[package]]
 name = "near-vm-logic"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "bs58",
@@ -3163,8 +3163,8 @@ dependencies = [
  "near-vm-errors 0.0.0",
  "ripemd",
  "serde",
- "sha2 0.10.2",
- "sha3 0.10.1",
+ "sha2 0.9.9",
+ "sha3",
  "zeropool-bn",
 ]
 
@@ -3183,13 +3183,13 @@ dependencies = [
  "near-vm-errors 4.0.0-pre.1",
  "serde",
  "sha2 0.9.9",
- "sha3 0.9.1",
+ "sha3",
 ]
 
 [[package]]
 name = "near-vm-runner"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "anyhow",
  "borsh 0.9.3",
@@ -3221,7 +3221,7 @@ dependencies = [
 [[package]]
 name = "nearcore"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "actix",
  "actix-rt",
@@ -3291,7 +3291,7 @@ dependencies = [
 [[package]]
 name = "node-runtime"
 version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=088a149c3f2708af64b0053e3d03df1dfee00e7e#088a149c3f2708af64b0053e3d03df1dfee00e7e"
+source = "git+https://github.com/near/nearcore?rev=776efa3b65cf92f2524fd349d5d720fe69807f07#776efa3b65cf92f2524fd349d5d720fe69807f07"
 dependencies = [
  "borsh 0.9.3",
  "byteorder",
@@ -4628,16 +4628,6 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
-]
-
-[[package]]
-name = "sha3"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "881bf8156c87b6301fc5ca6b27f11eeb2761224c7081e69b409d5a1951a70c86"
-dependencies = [
- "digest 0.10.3",
- "keccak",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.23"
+version = "0.10.24"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 
@@ -36,7 +36,7 @@ tracing-subscriber = "0.2.4"
 uint = { version = "0.8.3", default-features = false }
 
 actix-diesel = { git = "https://github.com/frol/actix-diesel", rev = "3a001986c89dfabfc3c448d8bae28525101b4992" }
-near-indexer = { git = "https://github.com/near/nearcore", rev = "088a149c3f2708af64b0053e3d03df1dfee00e7e" }
-near-crypto = { git = "https://github.com/near/nearcore", rev = "088a149c3f2708af64b0053e3d03df1dfee00e7e" }
-near-client = { git = "https://github.com/near/nearcore", rev = "088a149c3f2708af64b0053e3d03df1dfee00e7e" }
-near-metrics = { git = "https://github.com/near/nearcore", rev = "088a149c3f2708af64b0053e3d03df1dfee00e7e" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "776efa3b65cf92f2524fd349d5d720fe69807f07" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "776efa3b65cf92f2524fd349d5d720fe69807f07" }
+near-client = { git = "https://github.com/near/nearcore", rev = "776efa3b65cf92f2524fd349d5d720fe69807f07" }
+near-metrics = { git = "https://github.com/near/nearcore", rev = "776efa3b65cf92f2524fd349d5d720fe69807f07" }


### PR DESCRIPTION
https://github.com/near/nearcore/releases/tag/1.29.0-rc.2