### PR TITLE
refactor: base64::encode args manually since it is not encoded on `nearcore` side anymore

### DIFF
--- a/src/models/serializers.rs
+++ b/src/models/serializers.rs
@@ -82,7 +82,7 @@ pub(crate) fn extract_action_type_and_value_from_action_view(
         } => {
             let mut arguments = json!({
                 "method_name": method_name.escape_default().to_string(),
-                "args_base64": args,
+                "args_base64": base64::encode(&args),
                 "gas": gas,
                 "deposit": deposit.to_string(),
             });


### PR DESCRIPTION
As reported in issue #305 `args` in `FunctionCall` is no more base64 encoded on the `nearcore` side.
It is already affecting the testnet, so we have to encode arguments on the Indexer for the Explorer side.

ref: https://github.com/near/nearcore/commit/8e9be9fff4d520993c81b0e3738c0f223a9538c0#diff-1e4fc99d32e48420a9bd37050fa1412758cba37825851edea40cbdfcab406944L852