### PR TITLE
chore: Release 0.10.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.25
+
+* Update `serializer` to encode `args_base64` since `nearcore` is no more encoding `args` in `FunctionCall` Actions (fix of #305)
+
 ## 0.10.24
 
 * Upgrade `nearcore` to [`1.29.0-rc.2`](https://github.com/near/nearcore/releases/tag/1.29.0-rc.2) (according to nearcore release notes, it will require 3GB more RAM than before)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1981,7 +1981,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.10.24"
+version = "0.10.25"
 dependencies = [
  "actix",
  "actix-diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.24"
+version = "0.10.25"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 


### PR DESCRIPTION
The release includes the fix for #305

We will update testnet nodes once the release is cut.