### PR TITLE
fix: Action args_json must be extracted correctly whenever possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.28
+
+* Fixed function args extraction (`args->args_json`) for actions (`action_receipt_actions` and `transaction_actions` tables). This bug affected all the records since 0.10.22 release. Consider removing and re-indexing all the records from the time you deployed 0.10.22+ release.
+
 ## 0.10.27
 
 * Upgrade Indexer Framework to be based on [`nearcore` version `1.29.0`](https://github.com/near/nearcore/releases/tag/1.29.0)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.10.27"
+version = "0.10.28"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 

--- a/src/models/serializers.rs
+++ b/src/models/serializers.rs
@@ -88,14 +88,11 @@ pub(crate) fn extract_action_type_and_value_from_action_view(
             });
 
             // During denormalization of action_receipt_actions table we wanted to try to decode
-            // args which is base64 encoded in case if it is a JSON object and put them near initial
-            // args_base64
+            // args in case if it is a JSON object and put them along side with args_base64
             // See for reference https://github.com/near/near-indexer-for-explorer/issues/87
-            if let Ok(decoded_args) = base64::decode(args) {
-                if let Ok(mut args_json) = serde_json::from_slice(&decoded_args) {
-                    escape_json(&mut args_json);
-                    arguments["args_json"] = args_json;
-                }
+            if let Ok(mut args_json) = serde_json::from_slice(&args) {
+                escape_json(&mut args_json);
+                arguments["args_json"] = args_json;
             }
 
             (ActionKind::FunctionCall, arguments)


### PR DESCRIPTION
This PR fixes function args extraction (`args->args_json`) for actions (`action_receipt_actions` and `transaction_actions` tables). This bug affected all the records since 0.10.22 release. Consider removing and re-indexing all the records from the time you deployed 0.10.22+ release. I will also provide a patch that you can use to re-index without cleaning up the database and instead just run it over the existing data, so it will forcefully update the data.