### PR TITLE
fix: Avoid recreating access key on transfer to implicit account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.32
+
+* Avoid recreating access key on transfer to implicit account
+
 ## 0.10.31 - patch
 
 * Upgrade Indexer Framework to be based on [`nearcore` version 1.30.0 patched](https://github.com/near/nearcore/commit/267e36e39fb5bb29c1df23c73afbcaa750ce96b1)

--- a/src/db_adapters/access_keys.rs
+++ b/src/db_adapters/access_keys.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::convert::TryFrom;
 
 use actix_diesel::dsl::AsyncRunQueryDsl;
 use actix_diesel::Database;
@@ -15,107 +14,71 @@ use crate::{metrics, models};
 
 pub(crate) async fn handle_access_keys(
     pool: &actix_diesel::Database<PgConnection>,
-    outcomes: &[near_indexer::IndexerExecutionOutcomeWithReceipt],
+    state_changes: &[near_primitives::views::StateChangeWithCauseView],
     block_height: near_primitives::types::BlockHeight,
 ) -> anyhow::Result<()> {
     let _timer = metrics::STORE_TIME
         .with_label_values(&["AccessKeys"])
         .start_timer();
-    if outcomes.is_empty() {
+    if state_changes.is_empty() {
         return Ok(());
     }
-    let successful_receipts = outcomes
-        .iter()
-        .filter(|outcome_with_receipt| {
-            matches!(
-                outcome_with_receipt.execution_outcome.outcome.status,
-                near_primitives::views::ExecutionStatusView::SuccessValue(_)
-                    | near_primitives::views::ExecutionStatusView::SuccessReceiptId(_)
-            )
-        })
-        .map(|outcome_with_receipt| &outcome_with_receipt.receipt);
 
     let mut access_keys = HashMap::<(String, String), models::access_keys::AccessKey>::new();
     let mut deleted_accounts = HashMap::<String, String>::new();
 
-    for receipt in successful_receipts {
-        if let near_primitives::views::ReceiptEnumView::Action { actions, .. } = &receipt.receipt {
-            for action in actions {
-                match action {
-                    near_primitives::views::ActionView::DeleteAccount { .. } => {
-                        deleted_accounts.insert(
-                            receipt.receiver_id.to_string(),
-                            receipt.receipt_id.to_string(),
-                        );
-                        access_keys
-                            .iter_mut()
-                            .filter(|((_, receiver_id), _)| {
-                                receiver_id == receipt.receiver_id.as_ref()
-                            })
-                            .for_each(|(_, access_key)| {
-                                access_key.deleted_by_receipt_id =
-                                    Some(receipt.receipt_id.to_string());
-                            });
-                    }
-                    near_primitives::views::ActionView::AddKey {
-                        public_key,
-                        access_key,
-                    } => {
-                        access_keys.insert(
-                            (public_key.to_string(), receipt.receiver_id.to_string()),
-                            models::access_keys::AccessKey::from_action_view(
-                                public_key,
-                                &receipt.receiver_id,
-                                access_key,
-                                &receipt.receipt_id,
-                                block_height,
-                            ),
-                        );
-                    }
-                    near_primitives::views::ActionView::DeleteKey { public_key } => {
-                        access_keys
-                            .entry((public_key.to_string(), receipt.receiver_id.to_string()))
-                            .and_modify(|existing_access_key| {
-                                existing_access_key.deleted_by_receipt_id =
-                                    Some(receipt.receipt_id.to_string());
-                            })
-                            .or_insert_with(|| models::access_keys::AccessKey {
-                                public_key: public_key.to_string(),
-                                account_id: receipt.receiver_id.to_string(),
-                                created_by_receipt_id: None,
-                                deleted_by_receipt_id: Some(receipt.receipt_id.to_string()),
-                                // this is a workaround to avoid additional struct with optional field
-                                // permission_kind is not supposed to change on delete action
-                                permission_kind: models::enums::AccessKeyPermission::FullAccess,
-                                last_update_block_height: block_height.into(),
-                            });
-                    }
-                    near_indexer::near_primitives::views::ActionView::Transfer { .. } => {
-                        if receipt.receiver_id.len() != 64usize {
-                            continue;
-                        }
-                        if let Ok(public_key_bytes) = hex::decode(receipt.receiver_id.as_ref()) {
-                            if let Ok(public_key) =
-                                near_crypto::ED25519PublicKey::try_from(&public_key_bytes[..])
-                            {
-                                access_keys.insert(
-                                    (near_crypto::PublicKey::from(public_key.clone()).to_string(), receipt.receiver_id.to_string()),
-                                    models::access_keys::AccessKey::from_action_view(
-                                        &near_crypto::PublicKey::from(public_key.clone()),
-                                        &receipt.receiver_id,
-                                        &near_primitives::views::AccessKeyView {
-                                            nonce: 0,
-                                            permission: near_primitives::views::AccessKeyPermissionView::FullAccess
-                                        },
-                                        &receipt.receipt_id,
-                                        block_height,
-                                    ),
-                                );
-                            }
-                        }
-                    }
-                    _ => continue,
+    for state_change in state_changes {
+        if let near_primitives::views::StateChangeCauseView::ReceiptProcessing { receipt_hash } =
+            state_change.cause
+        {
+            match &state_change.value {
+                near_primitives::views::StateChangeValueView::AccountDeletion { account_id } => {
+                    deleted_accounts.insert(account_id.to_string(), receipt_hash.to_string());
+                    access_keys
+                        .iter_mut()
+                        .filter(|((_, receiver_id), _)| receiver_id == &account_id.to_string())
+                        .for_each(|(_, access_key)| {
+                            access_key.deleted_by_receipt_id = Some(receipt_hash.to_string());
+                        });
                 }
+                near_primitives::views::StateChangeValueView::AccessKeyUpdate {
+                    account_id,
+                    public_key,
+                    access_key,
+                } => {
+                    access_keys.insert(
+                        (public_key.to_string(), account_id.to_string()),
+                        models::access_keys::AccessKey::from_action_view(
+                            public_key,
+                            &account_id,
+                            access_key,
+                            &receipt_hash,
+                            block_height,
+                        ),
+                    );
+                }
+                near_primitives::views::StateChangeValueView::AccessKeyDeletion {
+                    account_id,
+                    public_key,
+                } => {
+                    access_keys
+                        .entry((public_key.to_string(), account_id.to_string()))
+                        .and_modify(|existing_access_key| {
+                            existing_access_key.deleted_by_receipt_id =
+                                Some(receipt_hash.to_string());
+                        })
+                        .or_insert_with(|| models::access_keys::AccessKey {
+                            public_key: public_key.to_string(),
+                            account_id: account_id.to_string(),
+                            created_by_receipt_id: None,
+                            deleted_by_receipt_id: Some(receipt_hash.to_string()),
+                            // this is a workaround to avoid additional struct with optional field
+                            // permission_kind is not supposed to change on delete action
+                            permission_kind: models::enums::AccessKeyPermission::FullAccess,
+                            last_update_block_height: block_height.into(),
+                        });
+                }
+                _ => continue,
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn handle_message(
             let futures = streamer_message.shards.iter().map(|shard| {
                 db_adapters::access_keys::handle_access_keys(
                     pool,
-                    &shard.receipt_execution_outcomes,
+                    &shard.state_changes,
                     streamer_message.block.header.height,
                 )
             });


### PR DESCRIPTION
This PR refactors the `access_keys` logic to be driven from [`StateChanges`](https://near-indexers.io/docs/data-flow-and-structures/structures/state_change#statechangewithcauseview) rather than [`ExecutionOutcomes`](https://near-indexers.io/docs/data-flow-and-structures/structures/execution_outcome), allowing us to remove the logic which indirectly creates an access key on every transfer to an implicit account. This means access keys will only be written when the implicit account is first created, and ignore subsequent transfers. Resolves https://github.com/near/near-indexer-for-explorer/issues/304.

Test plan:
- [x] verified access key updates still function as expected by running the `StateChange`/`ExecutionOutcome` logic simultaneously and comparing the proposed DB updates.
- [x] verified that access keys for implicit accounts are not overwritten on subsequent transfers (specifically `deleted_by_receipt_id` and `created_by_receipt_id`)