### PR TITLE
chore: Reindex `access_keys`

### DIFF
--- a/src/db_adapters/access_keys.rs
+++ b/src/db_adapters/access_keys.rs
@@ -82,20 +82,20 @@ pub(crate) async fn handle_access_keys(
 
     let update_access_keys_future = async {
         for value in access_keys_to_update {
-            let target = schema::access_keys::table
-                .filter(schema::access_keys::dsl::public_key.eq(value.public_key.clone()))
+            let target = schema::access_keys_reindexed::table
+                .filter(schema::access_keys_reindexed::dsl::public_key.eq(value.public_key.clone()))
                 .filter(
-                    schema::access_keys::dsl::last_update_block_height
+                    schema::access_keys_reindexed::dsl::last_update_block_height
                         .lt(value.last_update_block_height.clone()),
                 )
-                .filter(schema::access_keys::dsl::account_id.eq(value.account_id));
+                .filter(schema::access_keys_reindexed::dsl::account_id.eq(value.account_id));
 
             crate::await_retry_or_panic!(
                 diesel::update(target.clone())
                     .set((
-                        schema::access_keys::dsl::deleted_by_receipt_id
+                        schema::access_keys_reindexed::dsl::deleted_by_receipt_id
                             .eq(value.deleted_by_receipt_id.clone()),
-                        schema::access_keys::dsl::last_update_block_height
+                        schema::access_keys_reindexed::dsl::last_update_block_height
                             .eq(value.last_update_block_height.clone()),
                     ))
                     .execute_async(pool),
@@ -109,7 +109,7 @@ pub(crate) async fn handle_access_keys(
 
     let add_access_keys_future = async {
         crate::await_retry_or_panic!(
-            diesel::insert_into(schema::access_keys::table)
+            diesel::insert_into(schema::access_keys_reindexed::table)
                 .values(access_keys_to_insert.clone())
                 .on_conflict_do_nothing()
                 .execute_async(pool),
@@ -119,22 +119,22 @@ pub(crate) async fn handle_access_keys(
         );
 
         for value in access_keys_to_insert {
-            let target = schema::access_keys::table
-                .filter(schema::access_keys::dsl::public_key.eq(value.public_key.clone()))
+            let target = schema::access_keys_reindexed::table
+                .filter(schema::access_keys_reindexed::dsl::public_key.eq(value.public_key.clone()))
                 .filter(
-                    schema::access_keys::dsl::last_update_block_height
+                    schema::access_keys_reindexed::dsl::last_update_block_height
                         .lt(value.last_update_block_height.clone()),
                 )
-                .filter(schema::access_keys::dsl::account_id.eq(value.account_id));
+                .filter(schema::access_keys_reindexed::dsl::account_id.eq(value.account_id));
 
             crate::await_retry_or_panic!(
                 diesel::update(target.clone())
                     .set((
-                        schema::access_keys::dsl::created_by_receipt_id
+                        schema::access_keys_reindexed::dsl::created_by_receipt_id
                             .eq(value.created_by_receipt_id.clone()),
-                        schema::access_keys::dsl::deleted_by_receipt_id
+                        schema::access_keys_reindexed::dsl::deleted_by_receipt_id
                             .eq(value.deleted_by_receipt_id.clone()),
-                        schema::access_keys::dsl::last_update_block_height
+                        schema::access_keys_reindexed::dsl::last_update_block_height
                             .eq(value.last_update_block_height.clone()),
                     ))
                     .execute_async(pool),
@@ -161,7 +161,7 @@ pub(crate) async fn store_access_keys_from_genesis(
     );
 
     crate::await_retry_or_panic!(
-        diesel::insert_into(schema::access_keys::table)
+        diesel::insert_into(schema::access_keys_reindexed::table)
             .values(access_keys_models.clone())
             .on_conflict_do_nothing()
             .execute_async(&pool),

--- a/src/models/access_keys.rs
+++ b/src/models/access_keys.rs
@@ -1,10 +1,10 @@
 use bigdecimal::BigDecimal;
 
 use crate::models::enums::AccessKeyPermission;
-use crate::schema;
-use schema::access_keys;
+use crate::schema::access_keys_reindexed;
 
 #[derive(Insertable, Clone, Debug)]
+#[table_name = "access_keys_reindexed"]
 pub struct AccessKey {
     pub public_key: String,
     pub account_id: String,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -31,6 +31,20 @@ table! {
     use diesel::sql_types::*;
     use crate::models::enums::*;
 
+    access_keys_reindexed (public_key, account_id) {
+        public_key -> Text,
+        account_id -> Text,
+        created_by_receipt_id -> Nullable<Text>,
+        deleted_by_receipt_id -> Nullable<Text>,
+        permission_kind -> Access_key_permission_kind,
+        last_update_block_height -> Numeric,
+    }
+}
+
+table! {
+    use diesel::sql_types::*;
+    use crate::models::enums::*;
+
     account_changes (id) {
         id -> Int8,
         affected_account_id -> Text,


### PR DESCRIPTION
Creating a temporary branch which modifies indexer so that it only writes to `access_keys_reindexed`. This is so we can reindex the entire `access_keys` table so that the data is not affected by the bug described in #304.

As I am not that familiar with the codebase, I wanted to create this PR to get a second pair of eyes and ensure I am on the right track. I'll pull down this branch on the testnet/mainnet machines to build the binary, rather than patching it on the machine directly.
