### PR TITLE
fix: improve performance of assets__* by changing PKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ And apply migrations
 $ cd database && diesel migration run
 ```
 
+Unfortunately, some migrations should be applied manually: [[1]](database/migrations/2021-08-06-123500_account_changes_ordering_column/up.sql), [[2]](database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql), [[3]](database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql).  
+If you have the DB with some data collected, and you forgot to apply some migrations to it, we suggest you to apply the changes manually with [`CONCURRENTLY` option](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY) enabled.
+This will help you not to block the tables while heavy operations are being applied.
+
 ### Compile NEAR Indexer for Explorer
 
 ```bash

--- a/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/down.sql
+++ b/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/down.sql
@@ -1,0 +1,25 @@
+-- These changes should be applied manually if needed
+
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_idx_tmp
+--     ON assets__fungible_token_events (emitted_for_receipt_id,
+--                                       emitted_at_block_timestamp,
+--                                       emitted_in_shard_id,
+--                                       emitted_index_of_event_entry_in_shard,
+--                                       emitted_by_contract_account_id,
+--                                       amount,
+--                                       event_kind,
+--                                       token_old_owner_account_id,
+--                                       token_new_owner_account_id,
+--                                       event_memo);
+--
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_token_events_unique
+--     ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
+--
+-- -- This block runs ~1 sec
+-- BEGIN TRANSACTION;
+-- ALTER TABLE assets__fungible_token_events
+--     DROP CONSTRAINT assets__fungible_token_events_pkey;
+-- -- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
+-- ALTER TABLE assets__fungible_token_events
+--     ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+-- COMMIT;

--- a/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql
+++ b/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql
@@ -1,0 +1,16 @@
+-- These changes should be applied manually
+
+-- -- Without CONCURRENTLY, this command will block the table for more than 1 hour
+-- -- With CONCURRENTLY, it does not block anything, but it couldn't be applied as migration
+-- -- So we have to apply all these changes manually
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_idx_tmp
+--     ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
+--
+-- -- This block runs ~1 sec
+-- BEGIN TRANSACTION;
+-- ALTER TABLE assets__fungible_token_events DROP CONSTRAINT assets__fungible_token_events_pkey;
+-- ALTER TABLE assets__fungible_token_events DROP CONSTRAINT assets__fungible_token_events_unique;
+-- -- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
+-- ALTER TABLE assets__fungible_token_events
+--     ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+-- COMMIT;

--- a/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/down.sql
+++ b/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/down.sql
@@ -1,0 +1,26 @@
+-- These changes should be applied manually if needed
+
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_idx_tmp
+--     ON assets__non_fungible_token_events (emitted_for_receipt_id,
+--                                           emitted_at_block_timestamp,
+--                                           emitted_in_shard_id,
+--                                           emitted_index_of_event_entry_in_shard,
+--                                           emitted_by_contract_account_id,
+--                                           token_id,
+--                                           event_kind,
+--                                           token_old_owner_account_id,
+--                                           token_new_owner_account_id,
+--                                           token_authorized_account_id,
+--                                           event_memo);
+--
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_token_events_unique
+--     ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
+--
+-- -- This block runs ~1 sec
+-- BEGIN TRANSACTION;
+-- ALTER TABLE assets__non_fungible_token_events
+--     DROP CONSTRAINT assets__non_fungible_token_events_pkey;
+-- -- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
+-- ALTER TABLE assets__non_fungible_token_events
+--     ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+-- COMMIT;

--- a/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql
+++ b/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql
@@ -1,0 +1,16 @@
+-- These changes should be applied manually
+
+-- -- Without CONCURRENTLY, this command will block the table for more than 1 hour
+-- -- With CONCURRENTLY, it does not block anything, but it couldn't be applied as migration
+-- -- So we have to apply all these changes manually
+-- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_idx_tmp
+--     ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
+--
+-- -- This block runs ~1 sec
+-- BEGIN TRANSACTION;
+-- ALTER TABLE assets__non_fungible_token_events DROP CONSTRAINT assets__non_fungible_token_events_pkey;
+-- ALTER TABLE assets__non_fungible_token_events DROP CONSTRAINT assets__non_fungible_token_events_unique;
+-- -- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
+-- ALTER TABLE assets__non_fungible_token_events
+--     ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+-- COMMIT;


### PR DESCRIPTION
These changes have a major issue: when someone runs the project on the empty DB, the final state will not be accurate. I have no idea how to force users to read the migrations and run something manually.

I can uncomment everything and drop `CONCURRENTLY`: in this case, people with empty DB will be happy, while the others will have few hours blocking operation, which is unacceptable.

What do you guys think?