### PR TITLE
fix: rewrite last assets migrations, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ And apply migrations
 $ cd database && diesel migration run
 ```
 
-Unfortunately, some migrations should be applied manually: [[1]](database/migrations/2021-08-06-123500_account_changes_ordering_column/up.sql), [[2]](database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql), [[3]](database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql).  
-If you have the DB with some data collected, and you forgot to apply some migrations to it, we suggest you to apply the changes manually with [`CONCURRENTLY` option](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY) enabled.
-This will help you not to block the tables while heavy operations are being applied.
+If you have the DB with some data collected, and you need to apply the next migration, we highly recommend to read the migration contents.  
+Some migrations have the explanations what should be done, e.g. [[1]](database/migrations/2021-08-06-123500_account_changes_ordering_column/up.sql), [[2]](database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql), [[3]](database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql).  
+General advice is to add [`CONCURRENTLY` option](https://www.postgresql.org/docs/current/sql-createindex.html#SQL-CREATEINDEX-CONCURRENTLY) to all indexes creation and apply such changes manually.
 
 ### Compile NEAR Indexer for Explorer
 

--- a/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/down.sql
+++ b/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/down.sql
@@ -1,25 +1,27 @@
--- These changes should be applied manually if needed
+-- These commands are heavy for the full DB, consider adding CONCURRENTLY
+CREATE UNIQUE INDEX assets__fungible_idx_tmp
+    ON assets__fungible_token_events (emitted_for_receipt_id,
+                                      emitted_at_block_timestamp,
+                                      emitted_in_shard_id,
+                                      emitted_index_of_event_entry_in_shard,
+                                      emitted_by_contract_account_id,
+                                      amount,
+                                      event_kind,
+                                      token_old_owner_account_id,
+                                      token_new_owner_account_id,
+                                      event_memo);
+CREATE UNIQUE INDEX assets__fungible_token_events_unique
+    ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
 
--- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_idx_tmp
---     ON assets__fungible_token_events (emitted_for_receipt_id,
---                                       emitted_at_block_timestamp,
---                                       emitted_in_shard_id,
---                                       emitted_index_of_event_entry_in_shard,
---                                       emitted_by_contract_account_id,
---                                       amount,
---                                       event_kind,
---                                       token_old_owner_account_id,
---                                       token_new_owner_account_id,
---                                       event_memo);
---
--- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_token_events_unique
---     ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
---
--- -- This block runs ~1 sec
+-- Next block runs ~1 sec even on the full DB
+-- If you apply this manually, uncomment BEGIN TRANSACTION and COMMIT
+
 -- BEGIN TRANSACTION;
--- ALTER TABLE assets__fungible_token_events
---     DROP CONSTRAINT assets__fungible_token_events_pkey;
--- -- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
--- ALTER TABLE assets__fungible_token_events
---     ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+SAVEPOINT change_ft_pks_back;
+ALTER TABLE assets__fungible_token_events
+    DROP CONSTRAINT assets__fungible_token_events_pkey;
+-- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
+ALTER TABLE assets__fungible_token_events
+    ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+RELEASE SAVEPOINT change_ft_pks_back;
 -- COMMIT;

--- a/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql
+++ b/database/migrations/2023-02-02-100000_fungible_token_events_pk_changed/up.sql
@@ -1,16 +1,18 @@
--- These changes should be applied manually
+-- This command is heavy for the full DB, consider adding CONCURRENTLY
+CREATE UNIQUE INDEX assets__fungible_idx_tmp
+    ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
 
--- -- Without CONCURRENTLY, this command will block the table for more than 1 hour
--- -- With CONCURRENTLY, it does not block anything, but it couldn't be applied as migration
--- -- So we have to apply all these changes manually
--- CREATE UNIQUE INDEX CONCURRENTLY assets__fungible_idx_tmp
---     ON assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
---
--- -- This block runs ~1 sec
+-- Next block runs ~1 sec even on the full DB
+-- If you apply this manually, uncomment BEGIN TRANSACTION and COMMIT
+
 -- BEGIN TRANSACTION;
--- ALTER TABLE assets__fungible_token_events DROP CONSTRAINT assets__fungible_token_events_pkey;
--- ALTER TABLE assets__fungible_token_events DROP CONSTRAINT assets__fungible_token_events_unique;
--- -- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
--- ALTER TABLE assets__fungible_token_events
---     ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+SAVEPOINT change_ft_pks;
+ALTER TABLE assets__fungible_token_events
+    DROP CONSTRAINT assets__fungible_token_events_pkey;
+ALTER TABLE assets__fungible_token_events
+    DROP CONSTRAINT assets__fungible_token_events_unique;
+-- This command will automatically rename assets__fungible_idx_tmp to assets__fungible_token_events_pkey
+ALTER TABLE assets__fungible_token_events
+    ADD CONSTRAINT assets__fungible_token_events_pkey PRIMARY KEY USING INDEX assets__fungible_idx_tmp;
+RELEASE SAVEPOINT change_ft_pks;
 -- COMMIT;

--- a/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/down.sql
+++ b/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/down.sql
@@ -1,26 +1,28 @@
--- These changes should be applied manually if needed
+-- These commands are heavy for the full DB, consider adding CONCURRENTLY
+CREATE UNIQUE INDEX assets__non_fungible_idx_tmp
+    ON assets__non_fungible_token_events (emitted_for_receipt_id,
+                                          emitted_at_block_timestamp,
+                                          emitted_in_shard_id,
+                                          emitted_index_of_event_entry_in_shard,
+                                          emitted_by_contract_account_id,
+                                          token_id,
+                                          event_kind,
+                                          token_old_owner_account_id,
+                                          token_new_owner_account_id,
+                                          token_authorized_account_id,
+                                          event_memo);
+CREATE UNIQUE INDEX assets__non_fungible_token_events_unique
+    ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
 
--- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_idx_tmp
---     ON assets__non_fungible_token_events (emitted_for_receipt_id,
---                                           emitted_at_block_timestamp,
---                                           emitted_in_shard_id,
---                                           emitted_index_of_event_entry_in_shard,
---                                           emitted_by_contract_account_id,
---                                           token_id,
---                                           event_kind,
---                                           token_old_owner_account_id,
---                                           token_new_owner_account_id,
---                                           token_authorized_account_id,
---                                           event_memo);
---
--- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_token_events_unique
---     ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
---
--- -- This block runs ~1 sec
+-- Next block runs ~1 sec even on the full DB
+-- If you apply this manually, uncomment BEGIN TRANSACTION and COMMIT
+
 -- BEGIN TRANSACTION;
--- ALTER TABLE assets__non_fungible_token_events
---     DROP CONSTRAINT assets__non_fungible_token_events_pkey;
--- -- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
--- ALTER TABLE assets__non_fungible_token_events
---     ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+SAVEPOINT change_nft_pks_back;
+ALTER TABLE assets__non_fungible_token_events
+    DROP CONSTRAINT assets__non_fungible_token_events_pkey;
+-- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
+ALTER TABLE assets__non_fungible_token_events
+    ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+RELEASE SAVEPOINT change_nft_pks_back;
 -- COMMIT;

--- a/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql
+++ b/database/migrations/2023-02-02-110000_non_fungible_token_events_pk_changed/up.sql
@@ -1,16 +1,18 @@
--- These changes should be applied manually
+-- This command is heavy for the full DB, consider adding CONCURRENTLY
+CREATE UNIQUE INDEX assets__non_fungible_idx_tmp
+    ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
 
--- -- Without CONCURRENTLY, this command will block the table for more than 1 hour
--- -- With CONCURRENTLY, it does not block anything, but it couldn't be applied as migration
--- -- So we have to apply all these changes manually
--- CREATE UNIQUE INDEX CONCURRENTLY assets__non_fungible_idx_tmp
---     ON assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard);
---
--- -- This block runs ~1 sec
+-- Next block runs ~1 sec even on the full DB
+-- If you apply this manually, uncomment BEGIN TRANSACTION and COMMIT
+
 -- BEGIN TRANSACTION;
--- ALTER TABLE assets__non_fungible_token_events DROP CONSTRAINT assets__non_fungible_token_events_pkey;
--- ALTER TABLE assets__non_fungible_token_events DROP CONSTRAINT assets__non_fungible_token_events_unique;
--- -- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
--- ALTER TABLE assets__non_fungible_token_events
---     ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+SAVEPOINT change_nft_pks;
+ALTER TABLE assets__non_fungible_token_events
+    DROP CONSTRAINT assets__non_fungible_token_events_pkey;
+ALTER TABLE assets__non_fungible_token_events
+    DROP CONSTRAINT assets__non_fungible_token_events_unique;
+-- This command will automatically rename assets__non_fungible_idx_tmp to assets__non_fungible_token_events_pkey
+ALTER TABLE assets__non_fungible_token_events
+    ADD CONSTRAINT assets__non_fungible_token_events_pkey PRIMARY KEY USING INDEX assets__non_fungible_idx_tmp;
+RELEASE SAVEPOINT change_nft_pks;
 -- COMMIT;


### PR DESCRIPTION
I realised that we cheat on our users in the previous PR #343. 
It's been a long time when we add the migrations which is impossible to apply on the full DB: we just know about that and apply these changes manually with `CONCURRENTLY` option enabled.

I fixed the last 2 transactions so that it works well on the empty DB;
I also added the explanations to the README, adding the instruction how to apply the new migrations on the full DB.