### PR TITLE
refactor: rearrange methods in tx_actions, receipt_actions

### DIFF
--- a/database/src/adapters/execution_outcomes.rs
+++ b/database/src/adapters/execution_outcomes.rs
@@ -18,7 +18,7 @@ pub async fn store_execution_outcomes(
             &shard.receipt_execution_outcomes,
             shard.shard_id,
             block_timestamp,
-            std::sync::Arc::clone(&receipts_cache),
+            receipts_cache.clone(),
         )
     });
 

--- a/database/src/adapters/receipts.rs
+++ b/database/src/adapters/receipts.rs
@@ -512,7 +512,7 @@ async fn store_action_receipts(
             .on_conflict_do_nothing()
             .execute_async(pool),
         10,
-        "ReceiptActions were stored in database".to_string(),
+        "Failed to store ReceiptActions in database".to_string(),
         &receipt_actions
     );
     Ok(())

--- a/database/src/adapters/receipts.rs
+++ b/database/src/adapters/receipts.rs
@@ -60,7 +60,7 @@ async fn store_chunk_receipts(
         strict_mode,
         block_hash,
         chunk_hash,
-        std::sync::Arc::clone(&receipts_cache),
+        receipts_cache.clone(),
     )
     .await?;
 
@@ -146,9 +146,9 @@ async fn store_chunk_receipts(
         });
 
     let process_receipt_actions_future =
-        store_receipt_actions(pool, action_receipts, block_timestamp);
+        store_receipt_actions(pool, &action_receipts, block_timestamp);
 
-    let process_receipt_data_future = store_receipt_data(pool, data_receipts);
+    let process_receipt_data_future = store_data_receipts(pool, &data_receipts);
 
     try_join!(process_receipt_actions_future, process_receipt_data_future)?;
     Ok(())
@@ -486,14 +486,43 @@ async fn save_receipts(
 
 async fn store_receipt_actions(
     pool: &actix_diesel::Database<PgConnection>,
-    receipts: Vec<&near_indexer_primitives::views::ReceiptView>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
     block_timestamp: u64,
+) -> anyhow::Result<()> {
+    try_join!(
+        store_action_receipts(pool, receipts),
+        store_action_receipt_actions(pool, receipts, block_timestamp),
+        store_action_receipt_input_data(pool, receipts),
+        store_action_receipt_output_data(pool, receipts),
+    )?;
+    Ok(())
+}
+
+async fn store_action_receipts(
+    pool: &actix_diesel::Database<PgConnection>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
 ) -> anyhow::Result<()> {
     let receipt_actions: Vec<models::ActionReceipt> = receipts
         .iter()
         .filter_map(|receipt| models::ActionReceipt::try_from(*receipt).ok())
         .collect();
+    crate::await_retry_or_panic!(
+        diesel::insert_into(schema::action_receipts::table)
+            .values(receipt_actions.clone())
+            .on_conflict_do_nothing()
+            .execute_async(pool),
+        10,
+        "ReceiptActions were stored in database".to_string(),
+        &receipt_actions
+    );
+    Ok(())
+}
 
+async fn store_action_receipt_actions(
+    pool: &actix_diesel::Database<PgConnection>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
+    block_timestamp: u64,
+) -> anyhow::Result<()> {
     let receipt_action_actions: Vec<models::ActionReceiptAction> = receipts
         .iter()
         .filter_map(|receipt| {
@@ -516,7 +545,22 @@ async fn store_receipt_actions(
         })
         .flatten()
         .collect();
+    crate::await_retry_or_panic!(
+        diesel::insert_into(schema::action_receipt_actions::table)
+            .values(receipt_action_actions.clone())
+            .on_conflict_do_nothing()
+            .execute_async(pool),
+        10,
+        "ReceiptActionActions were stored in database".to_string(),
+        &receipt_action_actions
+    );
+    Ok(())
+}
 
+async fn store_action_receipt_input_data(
+    pool: &actix_diesel::Database<PgConnection>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
+) -> anyhow::Result<()> {
     let receipt_action_input_data: Vec<models::ActionReceiptInputData> = receipts
         .iter()
         .filter_map(|receipt| {
@@ -536,7 +580,22 @@ async fn store_receipt_actions(
         })
         .flatten()
         .collect();
+    crate::await_retry_or_panic!(
+        diesel::insert_into(schema::action_receipt_input_data::table)
+            .values(receipt_action_input_data.clone())
+            .on_conflict_do_nothing()
+            .execute_async(pool),
+        10,
+        "ReceiptActionInputData were stored in database".to_string(),
+        &receipt_action_input_data
+    );
+    Ok(())
+}
 
+async fn store_action_receipt_output_data(
+    pool: &actix_diesel::Database<PgConnection>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
+) -> anyhow::Result<()> {
     let receipt_action_output_data: Vec<models::ActionReceiptOutputData> = receipts
         .iter()
         .filter_map(|receipt| {
@@ -559,26 +618,6 @@ async fn store_receipt_actions(
         .collect();
 
     crate::await_retry_or_panic!(
-        diesel::insert_into(schema::action_receipts::table)
-            .values(receipt_actions.clone())
-            .on_conflict_do_nothing()
-            .execute_async(pool),
-        10,
-        "ReceiptActions were stored in database".to_string(),
-        &receipt_actions
-    );
-
-    crate::await_retry_or_panic!(
-        diesel::insert_into(schema::action_receipt_actions::table)
-            .values(receipt_action_actions.clone())
-            .on_conflict_do_nothing()
-            .execute_async(pool),
-        10,
-        "ReceiptActionActions were stored in database".to_string(),
-        &receipt_action_actions
-    );
-
-    crate::await_retry_or_panic!(
         diesel::insert_into(schema::action_receipt_output_data::table)
             .values(receipt_action_output_data.clone())
             .on_conflict_do_nothing()
@@ -587,23 +626,12 @@ async fn store_receipt_actions(
         "ReceiptActionOutputData were stored in database".to_string(),
         &receipt_action_output_data
     );
-
-    crate::await_retry_or_panic!(
-        diesel::insert_into(schema::action_receipt_input_data::table)
-            .values(receipt_action_input_data.clone())
-            .on_conflict_do_nothing()
-            .execute_async(pool),
-        10,
-        "ReceiptActionInputData were stored in database".to_string(),
-        &receipt_action_input_data
-    );
-
     Ok(())
 }
 
-async fn store_receipt_data(
+async fn store_data_receipts(
     pool: &actix_diesel::Database<PgConnection>,
-    receipts: Vec<&near_indexer_primitives::views::ReceiptView>,
+    receipts: &[&near_indexer_primitives::views::ReceiptView],
 ) -> anyhow::Result<()> {
     let receipt_data_models: Vec<models::DataReceipt> = receipts
         .iter()

--- a/database/src/adapters/transactions.rs
+++ b/database/src/adapters/transactions.rs
@@ -14,7 +14,7 @@ pub async fn store_transactions(
     block_hash: &near_indexer_primitives::CryptoHash,
     block_timestamp: u64,
     block_height: near_indexer_primitives::types::BlockHeight,
-    receipts_cache: crate::receipts_cache::ReceiptsCache,
+    receipts_cache_arc: crate::receipts_cache::ReceiptsCacheArc,
 ) -> anyhow::Result<()> {
     let mut tried_to_insert_transactions_count = 0;
     let tx_futures = shards
@@ -32,7 +32,7 @@ pub async fn store_transactions(
                 block_hash,
                 block_timestamp,
                 "",
-                receipts_cache.clone(),
+                receipts_cache_arc.clone(),
             )
         });
 
@@ -79,7 +79,7 @@ pub async fn store_transactions(
                 block_hash,
                 block_timestamp,
                 &transaction_hash_suffix,
-                receipts_cache.clone(),
+                receipts_cache_arc.clone(),
             )
         });
 
@@ -109,7 +109,7 @@ async fn store(
     block_timestamp: u64,
     // hack for supporting duplicated transaction hashes. Empty for most of transactions
     transaction_hash_suffix: &str,
-    receipts_cache: crate::receipts_cache::ReceiptsCache,
+    receipts_cache_arc: crate::receipts_cache::ReceiptsCacheArc,
 ) -> anyhow::Result<()> {
     store_chunk_transactions(
         pool,
@@ -118,7 +118,7 @@ async fn store(
         block_hash,
         block_timestamp,
         transaction_hash_suffix,
-        receipts_cache,
+        receipts_cache_arc,
     )
     .await?;
     let transactions = enumerated_transactions
@@ -139,9 +139,9 @@ async fn store_chunk_transactions(
     block_timestamp: u64,
     // hack for supporting duplicated transaction hashes. Empty for most of transactions
     transaction_hash_suffix: &str,
-    receipts_cache: crate::receipts_cache::ReceiptsCache,
+    receipts_cache_arc: crate::receipts_cache::ReceiptsCacheArc,
 ) -> anyhow::Result<()> {
-    let mut receipts_cache_lock = receipts_cache.lock().await;
+    let mut receipts_cache_lock = receipts_cache_arc.lock().await;
 
     let transaction_models: Vec<models::transactions::Transaction> = transactions
         .iter()

--- a/database/src/receipts_cache.rs
+++ b/database/src/receipts_cache.rs
@@ -12,5 +12,5 @@ pub type ParentTransactionHashString = String;
 // touching the database
 // The key is ReceiptID
 // The value is TransactionHash (the very parent of the Receipt)
-pub type ReceiptsCache =
+pub type ReceiptsCacheArc =
     std::sync::Arc<Mutex<SizedCache<ReceiptOrDataId, ParentTransactionHashString>>>;

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -46,7 +46,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         streamer_message.block.header.height,
-        std::sync::Arc::clone(&receipts_cache),
+        receipts_cache.clone(),
     );
 
     // Receipts
@@ -56,7 +56,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         strict_mode,
-        std::sync::Arc::clone(&receipts_cache),
+        receipts_cache.clone(),
     );
 
     // We can process transactions and receipts in parallel
@@ -71,7 +71,7 @@ async fn handle_message(
         pool,
         &streamer_message.shards,
         streamer_message.block.header.timestamp,
-        std::sync::Arc::clone(&receipts_cache),
+        receipts_cache.clone(),
     );
 
     // Accounts
@@ -181,12 +181,7 @@ async fn main() -> anyhow::Result<()> {
                 target: crate::INDEXER_FOR_EXPLORER,
                 "Block height {}", &streamer_message.block.header.height
             );
-            handle_message(
-                &pool,
-                streamer_message,
-                strict_mode,
-                std::sync::Arc::clone(&receipts_cache),
-            )
+            handle_message(&pool, streamer_message, strict_mode, receipts_cache.clone())
         })
         .buffer_unordered(1usize);
 

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -20,14 +20,14 @@ async fn handle_message(
     pool: &explorer_database::actix_diesel::Database<explorer_database::diesel::PgConnection>,
     streamer_message: near_lake_framework::near_indexer_primitives::StreamerMessage,
     strict_mode: bool,
-    receipts_cache: receipts_cache::ReceiptsCache,
+    receipts_cache_arc: receipts_cache::ReceiptsCacheArc,
 ) -> anyhow::Result<()> {
     metrics::BLOCK_COUNT.inc();
     metrics::LATEST_BLOCK_HEIGHT.set(streamer_message.block.header.height.try_into().unwrap());
 
     debug!(
         target: INDEXER_FOR_EXPLORER,
-        "ReceiptsCache #{} \n {:#?}", streamer_message.block.header.height, &receipts_cache
+        "ReceiptsCache #{} \n {:#?}", streamer_message.block.header.height, &receipts_cache_arc
     );
     adapters::blocks::store_block(pool, &streamer_message.block).await?;
 
@@ -46,7 +46,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         streamer_message.block.header.height,
-        receipts_cache.clone(),
+        receipts_cache_arc.clone(),
     );
 
     // Receipts
@@ -56,7 +56,7 @@ async fn handle_message(
         &streamer_message.block.header.hash,
         streamer_message.block.header.timestamp,
         strict_mode,
-        receipts_cache.clone(),
+        receipts_cache_arc.clone(),
     );
 
     // We can process transactions and receipts in parallel
@@ -71,7 +71,7 @@ async fn handle_message(
         pool,
         &streamer_message.shards,
         streamer_message.block.header.timestamp,
-        receipts_cache.clone(),
+        receipts_cache_arc.clone(),
     );
 
     // Accounts
@@ -162,7 +162,7 @@ async fn main() -> anyhow::Result<()> {
     // Later we need to find the Receipt which is a parent to underlying Receipts.
     // Receipt ID will of the child will be stored as key and parent Transaction hash/Receipt ID
     // will be stored as a value
-    let receipts_cache: receipts_cache::ReceiptsCache =
+    let receipts_cache_arc: receipts_cache::ReceiptsCacheArc =
         std::sync::Arc::new(Mutex::new(SizedCache::with_size(100_000)));
 
     let config: near_lake_framework::LakeConfig = opts.to_lake_config().await;
@@ -181,7 +181,12 @@ async fn main() -> anyhow::Result<()> {
                 target: crate::INDEXER_FOR_EXPLORER,
                 "Block height {}", &streamer_message.block.header.height
             );
-            handle_message(&pool, streamer_message, strict_mode, receipts_cache.clone())
+            handle_message(
+                &pool,
+                streamer_message,
+                strict_mode,
+                receipts_cache_arc.clone(),
+            )
         })
         .buffer_unordered(1usize);
 


### PR DESCRIPTION
I've made some refactoring before I'll introduce meta tx support logic
1. get rid of `std::sync::Arc::clone` because it looks scary to me, we can just use `.clone()` instead, the same method is used
2. split the methods. I'll add more logic to some of them further
3. parallelize receipts tables inserts, it should work a little faster with this change
4. fix a small bug in `transaction_actions`: tx_hash for duplicated transaction will point out to its parent instead of the first original tx