### PR TITLE
chore: Release 0.12.1 (bump version, update changelog)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2294,7 +2294,7 @@ dependencies = [
 
 [[package]]
 name = "indexer-explorer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "actix",
  "actix-rt",

--- a/indexer/CHANGELOG.md
+++ b/indexer/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 0.12.0
+## 0.12.1
+
+* Fix serialization issues we have since the switching to newer primitives (handling the pure `Vec<u8>` data as base64-encoded strings)
+
+## 0.12.0 (BROKEN, use 0.12.1)
 
 * Add support of [Meta Transactions](https://github.com/near/NEPs/pull/366) and upgrade near-indexer-primitives to `0.16.0`
 * Add [new columns](../database/migrations/2023-02-28-160000_meta_tx/up.sql) to `transaction_actions` and `action_receipt_actions` for supporting Meta Transactions (as usual, read [the migration](../database/migrations/2023-02-28-160000_meta_tx/up.sql) before applying if your DB is not empty)

--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "indexer-explorer"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["Near Inc <hello@nearprotocol.com>"]
 edition = "2021"
 rust-version = "1.64"


### PR DESCRIPTION
- Bump version
- Update CHANGELOG

FYI I have deleted the 0.12.0 release since it is broken