### PR TITLE
fix: Remove decoding of lockup contract as its now handled by nearcore

### DIFF
--- a/circulating-supply/Cargo.toml
+++ b/circulating-supply/Cargo.toml
@@ -22,8 +22,6 @@ uint = { version = "0.8.3", default-features = false }
 
 near-indexer-primitives = "0.16.0"
 near-jsonrpc-client = "0.5.0"
-# Remove manual base64 decoding of lockup state when upgrading to 0.15
-# https://github.com/khorolets/near-indexer-for-explorer/blob/master-lake/circulating_supply/src/lockup.rs#L60
 near-jsonrpc-primitives = "0.16.0"
 
 explorer-database = { path = '../database' }

--- a/circulating-supply/src/lockup.rs
+++ b/circulating-supply/src/lockup.rs
@@ -59,10 +59,7 @@ pub(super) async fn get_lockup_contract_state(
         )
     })?;
 
-    let decoded_view_state = base64::decode(&view_state.value)
-        .context(format!("Failed to decode lockup state for: {}", account_id))?;
-
-    let mut state = LockupContract::try_from_slice(&decoded_view_state)
+    let mut state = LockupContract::try_from_slice(&view_state.value)
         .with_context(|| format!("Failed to construct LockupContract for {}", account_id))?;
 
     // If owner of the lockup account didn't call the


### PR DESCRIPTION
Version `0.15` of `near-jsonrpc-primitives` returns values which are already `base64` decoded, making our manual decoding superfluous. When upgrading `0.16` we forgot to remove it, removing it now to fix the circulating supply computation.