### PR TITLE
Hide tables to a separate schema

### DIFF
--- a/database/diesel.toml
+++ b/database/diesel.toml
@@ -3,6 +3,8 @@
 
 [print_schema]
 file = "src/schema.rs"
+# Temporary add this if you need to update something in deprecated schema (and comment filter section)
+# schema = "deprecated"
 patch_file = "src/schema.patch"
 import_types = ["diesel::sql_types::*", "crate::models::enums::*"]
 # Exclicitly setting `only_tables` to avoid technical tables created by diesel to be included in schema
@@ -21,8 +23,9 @@ filter = { only_tables = [
     "transaction_actions",
     "accounts",
     "access_keys",
-    "account_changes",
     "aggregated__circulating_supply",
     "assets__non_fungible_token_events",
-    "assets__fungible_token_events"
+    # It does not work, diesel track only one schema (public by default). But let's leave it here as a doc
+    # "deprecated.account_changes",
+    # "deprecated.assets__fungible_token_events"
 ] }

--- a/database/migrations/2023-04-20-160000_deprecated_namespace/down.sql
+++ b/database/migrations/2023-04-20-160000_deprecated_namespace/down.sql
@@ -1,0 +1,3 @@
+ALTER TABLE deprecated.account_changes SET SCHEMA public;
+ALTER TABLE deprecated.assets__fungible_token_events SET SCHEMA public;
+DROP SCHEMA deprecated;

--- a/database/migrations/2023-04-20-160000_deprecated_namespace/up.sql
+++ b/database/migrations/2023-04-20-160000_deprecated_namespace/up.sql
@@ -1,0 +1,3 @@
+CREATE SCHEMA deprecated;
+ALTER TABLE public.account_changes SET SCHEMA deprecated;
+ALTER TABLE public.assets__fungible_token_events SET SCHEMA deprecated;

--- a/database/src/schema.patch
+++ b/database/src/schema.patch
@@ -1,5 +1,5 @@
 diff --git a/database/src/schema.rs b/database/src/schema.rs
-index c1c1c59..c5ffcf2 100644
+index bf5a951..a1fdabd 100644
 --- a/database/src/schema.rs
 +++ b/database/src/schema.rs
 @@ -1,6 +1,21 @@
@@ -24,21 +24,38 @@ index c1c1c59..c5ffcf2 100644
  
      access_keys (public_key, account_id) {
          public_key -> Text,
-@@ -30,13 +45,12 @@ table! {
-         index_in_block -> Int4,
-     }
+@@ -13,12 +28,30 @@ table! {
  }
  
  table! {
      use diesel::sql_types::*;
--    use crate::models::enums::*;
+     use crate::models::enums::*;
  
++    deprecated.account_changes (id) {
++        id -> Int8,
++        affected_account_id -> Text,
++        changed_in_block_timestamp -> Numeric,
++        changed_in_block_hash -> Text,
++        caused_by_transaction_hash -> Nullable<Text>,
++        caused_by_receipt_id -> Nullable<Text>,
++        update_reason -> State_change_reason_kind,
++        affected_account_nonstaked_balance -> Numeric,
++        affected_account_staked_balance -> Numeric,
++        affected_account_storage_usage -> Numeric,
++        index_in_block -> Int4,
++    }
++}
++
++table! {
++    use diesel::sql_types::*;
++
      accounts (id) {
          id -> Int8,
          account_id -> Text,
          created_by_receipt_id -> Nullable<Text>,
          deleted_by_receipt_id -> Nullable<Text>,
-@@ -61,47 +75,44 @@ table! {
+         last_update_block_height -> Numeric,
+@@ -42,47 +75,44 @@ table! {
          delegate_parent_index_in_action_receipt -> Nullable<Int4>,
      }
  }
@@ -87,7 +104,7 @@ index c1c1c59..c5ffcf2 100644
          circulating_tokens_supply -> Numeric,
          total_tokens_supply -> Numeric,
          total_lockup_contracts_count -> Int4,
-@@ -112,12 +123,13 @@ table! {
+@@ -93,12 +123,32 @@ table! {
  }
  
  table! {
@@ -95,19 +112,24 @@ index c1c1c59..c5ffcf2 100644
      use crate::models::enums::*;
  
 +    #[allow(non_snake_case)]
-     assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard) {
-         emitted_for_receipt_id -> Text,
-         emitted_at_block_timestamp -> Numeric,
-         emitted_in_shard_id -> Numeric,
-         emitted_index_of_event_entry_in_shard -> Int4,
-         emitted_by_contract_account_id -> Text,
-@@ -130,12 +142,13 @@ table! {
- }
- 
- table! {
-     use diesel::sql_types::*;
-     use crate::models::enums::*;
- 
++    deprecated.assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard) {
++        emitted_for_receipt_id -> Text,
++        emitted_at_block_timestamp -> Numeric,
++        emitted_in_shard_id -> Numeric,
++        emitted_index_of_event_entry_in_shard -> Int4,
++        emitted_by_contract_account_id -> Text,
++        amount -> Text,
++        event_kind -> Ft_event_kind,
++        token_old_owner_account_id -> Text,
++        token_new_owner_account_id -> Text,
++        event_memo -> Text,
++    }
++}
++
++table! {
++    use diesel::sql_types::*;
++    use crate::models::enums::*;
++
 +    #[allow(non_snake_case)]
      assets__non_fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard) {
          emitted_for_receipt_id -> Text,
@@ -115,7 +137,7 @@ index c1c1c59..c5ffcf2 100644
          emitted_in_shard_id -> Numeric,
          emitted_index_of_event_entry_in_shard -> Int4,
          emitted_by_contract_account_id -> Text,
-@@ -147,13 +160,22 @@ table! {
+@@ -110,13 +160,22 @@ table! {
          event_memo -> Text,
      }
  }
@@ -139,7 +161,7 @@ index c1c1c59..c5ffcf2 100644
          block_hash -> Text,
          prev_block_hash -> Text,
          block_timestamp -> Numeric,
-@@ -162,13 +184,12 @@ table! {
+@@ -125,13 +184,12 @@ table! {
          author_account_id -> Text,
      }
  }
@@ -153,7 +175,7 @@ index c1c1c59..c5ffcf2 100644
          chunk_hash -> Text,
          shard_id -> Numeric,
          signature -> Text,
-@@ -177,24 +198,22 @@ table! {
+@@ -140,24 +198,22 @@ table! {
          author_account_id -> Text,
      }
  }
@@ -178,3 +200,31 @@ index c1c1c59..c5ffcf2 100644
          index_in_execution_outcome -> Int4,
          produced_receipt_id -> Text,
      }
+@@ -231,12 +287,27 @@ table! {
+         converted_into_receipt_id -> Text,
+         receipt_conversion_gas_burnt -> Nullable<Numeric>,
+         receipt_conversion_tokens_burnt -> Nullable<Numeric>,
+     }
+ }
+ 
++joinable!(action_receipt_actions -> receipts (receipt_id));
++joinable!(aggregated__circulating_supply -> blocks (computed_at_block_hash));
++joinable!(assets__non_fungible_token_events -> receipts (emitted_for_receipt_id));
++joinable!(chunks -> blocks (included_in_block_hash));
++joinable!(execution_outcome_receipts -> execution_outcomes (executed_receipt_id));
++joinable!(execution_outcome_receipts -> receipts (executed_receipt_id));
++joinable!(execution_outcomes -> blocks (executed_in_block_hash));
++joinable!(execution_outcomes -> receipts (receipt_id));
++joinable!(receipts -> blocks (included_in_block_hash));
++joinable!(receipts -> chunks (included_in_chunk_hash));
++joinable!(receipts -> transactions (originated_from_transaction_hash));
++joinable!(transaction_actions -> transactions (transaction_hash));
++joinable!(transactions -> blocks (included_in_block_hash));
++joinable!(transactions -> chunks (included_in_chunk_hash));
++
+ allow_tables_to_appear_in_same_query!(
+     access_keys,
+     accounts,
+     action_receipt_actions,
+     action_receipt_input_data,
+     action_receipt_output_data,

--- a/database/src/schema.rs
+++ b/database/src/schema.rs
@@ -313,6 +313,7 @@ allow_tables_to_appear_in_same_query!(
     action_receipt_output_data,
     action_receipts,
     aggregated__circulating_supply,
+    assets__fungible_token_events,
     assets__non_fungible_token_events,
     blocks,
     chunks,

--- a/database/src/schema.rs
+++ b/database/src/schema.rs
@@ -31,7 +31,7 @@ table! {
     use diesel::sql_types::*;
     use crate::models::enums::*;
 
-    account_changes (id) {
+    deprecated.account_changes (id) {
         id -> Int8,
         affected_account_id -> Text,
         changed_in_block_timestamp -> Numeric,
@@ -127,7 +127,7 @@ table! {
     use crate::models::enums::*;
 
     #[allow(non_snake_case)]
-    assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard) {
+    deprecated.assets__fungible_token_events (emitted_for_receipt_id, emitted_index_of_event_entry_in_shard) {
         emitted_for_receipt_id -> Text,
         emitted_at_block_timestamp -> Numeric,
         emitted_in_shard_id -> Numeric,
@@ -290,12 +290,8 @@ table! {
     }
 }
 
-joinable!(account_changes -> blocks (changed_in_block_hash));
-joinable!(account_changes -> receipts (caused_by_receipt_id));
-joinable!(account_changes -> transactions (caused_by_transaction_hash));
 joinable!(action_receipt_actions -> receipts (receipt_id));
 joinable!(aggregated__circulating_supply -> blocks (computed_at_block_hash));
-joinable!(assets__fungible_token_events -> receipts (emitted_for_receipt_id));
 joinable!(assets__non_fungible_token_events -> receipts (emitted_for_receipt_id));
 joinable!(chunks -> blocks (included_in_block_hash));
 joinable!(execution_outcome_receipts -> execution_outcomes (executed_receipt_id));
@@ -311,14 +307,12 @@ joinable!(transactions -> chunks (included_in_chunk_hash));
 
 allow_tables_to_appear_in_same_query!(
     access_keys,
-    account_changes,
     accounts,
     action_receipt_actions,
     action_receipt_input_data,
     action_receipt_output_data,
     action_receipts,
     aggregated__circulating_supply,
-    assets__fungible_token_events,
     assets__non_fungible_token_events,
     blocks,
     chunks,


### PR DESCRIPTION
I tried to restrict selecting from 2 tables (see the full story [here](https://github.com/near/near-indexer-for-explorer/discussions/351)). I came to the conclusion that managed Postgres does not allow this.
That's why I created a `deprecated` schema, the users will not have access to it by default.

My plan is to move these tables to `deprecated` schema, hide them from all the users and see what happens.
We will still write the data to that tables.
If we break something important, we will grant access to the tables and consider how to fix it.
After a month of silence, we can drop them completely.

More tech details on what's going on here:
- Added migration
- Updated `schema.patch` so that it can generate the correct `schema.rs` file, it was a little broken
- Add the explanation of how diesel works with several schemas (TLDR: it does not work with several schemas, I hacked it)

I will also need to update the `features_enabled` branch. Waiting for your review first