### PR TITLE
fix: change log severity

### DIFF
--- a/database/src/retryable.rs
+++ b/database/src/retryable.rs
@@ -22,7 +22,7 @@ macro_rules! await_retry_or_panic {
                             break None;
                         })?
 
-                        tracing::error!(
+                        tracing::warn!(
                              target: $crate::EXPLORER_DATABASE,
                              "Error occurred during {}: \n{:#?} \n{:#?} \n Retrying in {} milliseconds...",
                              async_error,


### PR DESCRIPTION
We can have FK violation on transactions and receipts and it's our normal behaviour (we insert in an optimistica way, and the inserts usually go fine from 2 attempt)