### PR TITLE
Revert "Fix remove feature fungible_token_events"

### DIFF
--- a/indexer/Cargo.toml
+++ b/indexer/Cargo.toml
@@ -41,4 +41,4 @@ explorer-database = { path = "../database" }
 [features]
 default = []
 account_changes = []
-fungible_token_events = []
+fungible_token_events = ["explorer-database/fungible_token_events"]


### PR DESCRIPTION
Reverts near/near-indexer-for-explorer#384

That change does not remove the feature but makes it broken. 

The FT-related stuff mentioned in #384 is written from the hacky branch `features-enabled`. To disable the writings of FT-related stuff, the deployed instance should use the image built from `master` instead.