### PR TITLE
refactor: Improve non-strict-mode to make it even less strict

### DIFF
--- a/database/src/adapters/execution_outcomes.rs
+++ b/database/src/adapters/execution_outcomes.rs
@@ -87,7 +87,7 @@ pub async fn store_execution_outcomes_for_chunk(
             .values(outcome_models.clone())
             .on_conflict_do_nothing()
             .execute_async(pool),
-        10,
+        5,
         "ExecutionOutcomes were stored in database".to_string(),
         &outcome_models
     );
@@ -97,7 +97,7 @@ pub async fn store_execution_outcomes_for_chunk(
             .values(outcome_receipt_models.clone())
             .on_conflict_do_nothing()
             .execute_async(pool),
-        10,
+        5,
         "ExecutionOutcomeReceipts were stored in database".to_string(),
         &outcome_receipt_models
     );

--- a/database/src/adapters/receipts.rs
+++ b/database/src/adapters/receipts.rs
@@ -287,11 +287,11 @@ async fn find_tx_hashes_for_receipts(
                         }
                         Err(async_error) => {
                             error!(
-                            target: crate::EXPLORER_DATABASE,
-                            "Error occurred while fetching the parent receipt for Receipt. Retrying in {} milliseconds... \n {:#?}",
-                            interval.as_millis(),
-                            async_error,
-                        );
+                                target: crate::EXPLORER_DATABASE,
+                                "Error occurred while fetching the parent receipt for Receipt. Retrying in {} milliseconds... \n {:#?}",
+                                interval.as_millis(),
+                                async_error,
+                            );
                             tokio::time::sleep(interval).await;
                             if interval < crate::MAX_DELAY_TIME {
                                 interval *= 2;
@@ -464,13 +464,13 @@ async fn find_tx_hashes_for_receipts(
                 }
             }
             warn!(
-            target: crate::EXPLORER_DATABASE,
-            "Going to retry to find parent transactions for receipts in {} milliseconds... \n {:#?}\n block hash {} \nchunk hash {}",
-            find_tx_retry_interval.as_millis(),
-            &receipts,
-            block_hash,
-            chunk_hash
-        );
+                target: crate::EXPLORER_DATABASE,
+                "Going to retry to find parent transactions for receipts in {} milliseconds... \n {:#?}\n block hash {} \nchunk hash {}",
+                find_tx_retry_interval.as_millis(),
+                &receipts,
+                block_hash,
+                chunk_hash
+            );
             tokio::time::sleep(find_tx_retry_interval).await;
             if find_tx_retry_interval < crate::MAX_DELAY_TIME {
                 find_tx_retry_interval *= 2;

--- a/indexer/src/main.rs
+++ b/indexer/src/main.rs
@@ -265,7 +265,9 @@ async fn main() -> anyhow::Result<()> {
                 "Encountered error while indexing: {}",
                 e
             );
-            anyhow::bail!(e)
+            if strict_mode {
+                anyhow::bail!(e)
+            }
         }
     }
 


### PR DESCRIPTION
During our last refactoring sessions, we haven't paid enough attention to the `non-strict mode` for a while. Thus, this mode lost its nature and became too strict for its name. 

In this PR I've improved this mode to help us to get back on track:

- In non-strict mode we don't waste time and don't even attempt to find parent tx hash for the receipt in the DB (slow `SELECT`-queries make no sense for non-strict mode by slowing it down)
- The amount of attempts to store `ExecutionOutcomes` is reduced to 5 to complete in meaningful time (1600 ms or so)
- Prevent the entire indexer from shutting down if `handle_message` returns an error. Instead, we display a warning and proceed to the next block.

I've made a local check with an empty database setup and run an indexer with `non-strict-mode` + `from-latest` on the main net. In around 100 (or so) blocks, my indexer started writing new data to the database without massive retries. (I want to emphasize that some of the data wasn't stored as designed for `non-strict-mode`)

